### PR TITLE
[NZT-18] Reorganise corps label

### DIFF
--- a/__tests__/unit/components/Roll/Roll.test.tsx
+++ b/__tests__/unit/components/Roll/Roll.test.tsx
@@ -40,7 +40,7 @@ describe("Roll", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
-        name: "Driver Marty McFly 5th Reinforcements Army Pay Corps ?-†? →",
+        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
       }),
     ).toBeInTheDocument();
     expect(
@@ -76,7 +76,7 @@ describe("Roll", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", {
-        name: "Driver Marty McFly 5th Reinforcements Army Pay Corps ?-†? →",
+        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
       }),
     ).not.toBeInTheDocument();
     expect(
@@ -104,7 +104,7 @@ describe("Roll", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", {
-        name: "Driver Marty McFly 5th Reinforcements Army Pay Corps ?-†? →",
+        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
       }),
     ).toBeInTheDocument();
     expect(
@@ -132,7 +132,7 @@ describe("Roll", () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("link", {
-        name: "Driver Marty McFly 5th Reinforcements Army Pay Corps ?-†? →",
+        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
       }),
     ).not.toBeInTheDocument();
     expect(
@@ -161,7 +161,7 @@ describe("Roll", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
-        name: "Driver Marty McFly 5th Reinforcements Army Pay Corps ?-†? →",
+        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
       }),
     ).toBeInTheDocument();
     expect(
@@ -190,7 +190,7 @@ describe("Roll", () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("link", {
-        name: "Driver Marty McFly 5th Reinforcements Army Pay Corps ?-†? →",
+        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
       }),
     ).not.toBeInTheDocument();
     expect(
@@ -219,7 +219,7 @@ describe("Roll", () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("link", {
-        name: "Driver Marty McFly 5th Reinforcements Army Pay Corps ?-†? →",
+        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
       }),
     ).not.toBeInTheDocument();
     expect(

--- a/__tests__/unit/components/Roll/__snapshots__/Roll.test.tsx.snap
+++ b/__tests__/unit/components/Roll/__snapshots__/Roll.test.tsx.snap
@@ -346,7 +346,7 @@ exports[`Roll matches the snapshot 1`] = `
                   <p
                     class="detachment"
                   >
-                    Main Body 
+                    Main Body
                   </p>
                   <p
                     class="dates"
@@ -404,7 +404,7 @@ exports[`Roll matches the snapshot 1`] = `
                   <p
                     class="detachment"
                   >
-                    Main Body 
+                    Main Body
                   </p>
                   <p
                     class="dates"
@@ -448,6 +448,11 @@ exports[`Roll matches the snapshot 1`] = `
                     class="rank"
                   >
                     Driver
+                    <span
+                      class="badge"
+                    >
+                      Army Pay Corps
+                    </span>
                   </p>
                   <p
                     class="forename"
@@ -462,12 +467,7 @@ exports[`Roll matches the snapshot 1`] = `
                   <p
                     class="detachment"
                   >
-                    5th Reinforcements 
-                    <span
-                      class="badge"
-                    >
-                      Army Pay Corps
-                    </span>
+                    5th Reinforcements
                   </p>
                   <p
                     class="dates"
@@ -525,7 +525,7 @@ exports[`Roll matches the snapshot 1`] = `
                   <p
                     class="detachment"
                   >
-                    2nd Reinforcements 
+                    2nd Reinforcements
                   </p>
                   <p
                     class="dates"

--- a/components/Roll/RollDetails/RollDetails.module.scss
+++ b/components/Roll/RollDetails/RollDetails.module.scss
@@ -91,12 +91,20 @@
 
   .badge {
     margin-left: variables.$xxs-margin;
-    padding: variables.$xxxs-margin;
+    padding: 4px 6px;
     border-radius: 4px;
     color: variables.$primary-dark-color;
-    font-size: 0.75rem;
+    font-size: 0.65rem;
     font-weight: 500;
     text-transform: uppercase;
     background-color: variables.$secondary-color;
+
+    @include variables.tablet {
+      font-size: 0.75rem;
+    }
+
+    @include variables.desktop {
+      font-size: 0.75rem;
+    }
   }
 }

--- a/components/Roll/RollDetails/RollDetails.tsx
+++ b/components/Roll/RollDetails/RollDetails.tsx
@@ -28,17 +28,17 @@ export function RollDetails({ listOfTunnellers, isLoaded }: Props) {
           {isLoaded && (
             <div className={STYLES.tunneller}>
               <div>
-                <p className={STYLES.rank}>{tunneller.rank}</p>
-                <p className={STYLES.forename}>{tunneller.name.forename}</p>
-                <p className={STYLES.surname}>{tunneller.name.surname}</p>
-                <p className={STYLES.detachment}>
-                  {tunneller.detachment}{" "}
+                <p className={STYLES.rank}>
+                  {tunneller.rank}
                   {tunneller.attachedCorps ? (
                     <AttachedCorpsBadge
                       attachedCorps={tunneller.attachedCorps}
                     />
                   ) : null}
                 </p>
+                <p className={STYLES.forename}>{tunneller.name.forename}</p>
+                <p className={STYLES.surname}>{tunneller.name.surname}</p>
+                <p className={STYLES.detachment}>{tunneller.detachment}</p>
                 <p className={STYLES.dates}>
                   {displayBiographyDates(
                     tunneller.birthYear,


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
The corps label is not in the best place on the card as for small screen it can end up on two lines.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Change position of corps label.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
