### PR TITLE
[NZT-23] Add keyboard control for dropdown search

### DIFF
--- a/components/Menu/Menu.tsx
+++ b/components/Menu/Menu.tsx
@@ -49,6 +49,24 @@ export function Menu({ tunnellers }: Props) {
   }, [prevScrollPos]);
 
   useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setDropdownVisible(false);
+      } else if (event.key === "Enter") {
+        if (!dropdownVisible && filteredTunnellers.length > 0) {
+          setDropdownVisible(true);
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [dropdownVisible, filteredTunnellers]);
+
+  useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
         divRef.current &&

--- a/components/Menu/Menu.tsx
+++ b/components/Menu/Menu.tsx
@@ -52,7 +52,8 @@ export function Menu({ tunnellers }: Props) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setDropdownVisible(false);
-      } else if (event.key === "Enter") {
+      }
+      if (event.key === "Enter") {
         if (!dropdownVisible && filteredTunnellers.length > 0) {
           setDropdownVisible(true);
         }


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
The dropdown for the search bar does not have keyboard control for closing and reopening.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Add keyboard control (esc key to close; enter to open the dropdown).

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
