### PR TITLE
[NZT-25] Add alt for images on the timeline

### DIFF
--- a/__tests__/unit/components/Timeline/TimelineEvent.test.tsx
+++ b/__tests__/unit/components/Timeline/TimelineEvent.test.tsx
@@ -45,8 +45,8 @@ test("should render a timeline", () => {
 
   expect(screen.getByText("Something happened that day")).toBeInTheDocument();
 
-  const image = screen.getByRole("presentation");
-  expect(image).toHaveAttribute("alt", "");
+  const image = screen.getByRole("img", { name: "Company event image" });
+  expect(image).toHaveAttribute("alt", "Company event image");
   expect(image).toHaveAttribute(
     "src",
     "/_next/image?url=%2Fimages%2Froll%2Fimage.jpg&w=1920&q=75",

--- a/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`Timeline matches the snapshot 1`] = `
                   class="company-event"
                 >
                   <img
-                    alt=""
+                    alt="Company event image"
                     class="event-image"
                     data-nimg="1"
                     decoding="async"
@@ -266,7 +266,7 @@ exports[`Timeline matches the snapshot 1`] = `
                   class="company-event"
                 >
                   <img
-                    alt=""
+                    alt="Company event image"
                     class="event-image"
                     data-nimg="1"
                     decoding="async"

--- a/__tests__/unit/components/Timeline/__snapshots__/TimelineEvents.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/TimelineEvents.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`should render TimelineEvents 1`] = `
             class="company-event"
           >
             <img
-              alt=""
+              alt="Company event image"
               class="event-image"
               data-nimg="1"
               decoding="async"
@@ -216,7 +216,7 @@ exports[`should render TimelineEvents 1`] = `
             class="company-event"
           >
             <img
-              alt=""
+              alt="Company event image"
               class="event-image"
               data-nimg="1"
               decoding="async"

--- a/components/Timeline/TimelineEvent/TimelineEvent.tsx
+++ b/components/Timeline/TimelineEvent/TimelineEvent.tsx
@@ -37,7 +37,6 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
 
         if (title) {
           if (isTitleCompany) {
-            console.log(eventDetail);
             return (
               <div key={event.indexOf(eventDetail)}>
                 <div className={STYLES["company-event"]}>

--- a/components/Timeline/TimelineEvent/TimelineEvent.tsx
+++ b/components/Timeline/TimelineEvent/TimelineEvent.tsx
@@ -37,12 +37,13 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
 
         if (title) {
           if (isTitleCompany) {
+            console.log(eventDetail);
             return (
               <div key={event.indexOf(eventDetail)}>
                 <div className={STYLES["company-event"]}>
                   <Image
                     src={`/images/roll/${eventDetail.image}`}
-                    alt=""
+                    alt={eventDetail.imageAlt ?? "Company event image"}
                     width={670}
                     height={489}
                     className={STYLES["event-image"]}

--- a/docs/database.md
+++ b/docs/database.md
@@ -655,12 +655,13 @@ The database holds data for:
 
 ### Company Events
 
-| Column                 | Type       | Key     | Default | Description              |
-| ---------------------- | ---------- | ------- | ------- | ------------------------ |
-| `company_events_id`    | `smallint` | Primary | -       | -                        |
-| `company_events_date`  | `date`     | -       | -       | Date of the event        |
-| `company_events_title` | `tinytext` | -       | `NULL`  | Title of the event       |
-| `company_events_event` | `tinytext` | -       | -       | Description of the event |
-| `company_events_img`   | `tinytext` | -       | `NULL`  | Image if applicable      |
+| Column                   | Type       | Key     | Default | Description              |
+| ------------------------ | ---------- | ------- | ------- | ------------------------ |
+| `company_events_id`      | `smallint` | Primary | -       | -                        |
+| `company_events_date`    | `date`     | -       | -       | Date of the event        |
+| `company_events_title`   | `tinytext` | -       | `NULL`  | Title of the event       |
+| `company_events_event`   | `tinytext` | -       | -       | Description of the event |
+| `company_events_img`     | `tinytext` | -       | `NULL`  | Image if applicable      |
+| `company_events_img_alt` | `tinytext` | -       | `NULL`  | Alt for image            |
 
 [↑ Back to Tunnellers Tables](#tunnellers)

--- a/types/tunneller.ts
+++ b/types/tunneller.ts
@@ -89,6 +89,7 @@ export type SingleEventData = {
   event: string;
   title: string | null;
   image: string | null;
+  imageAlt?: string | null;
   extraDescription?: string | null;
 };
 
@@ -97,6 +98,7 @@ export type EventData = {
   event: string;
   title: string;
   image: string | null;
+  imageAlt?: string | null;
   extraDescription?: string | null;
 };
 
@@ -200,6 +202,7 @@ export type EventDetail = {
   description: string;
   title: string | null;
   image: string | null;
+  imageAlt?: string | null;
   extraDescription?: string | null;
 };
 

--- a/utils/database/queries/companyEventsQuery.ts
+++ b/utils/database/queries/companyEventsQuery.ts
@@ -4,6 +4,7 @@ export const companyEventsQuery = async (connection: any) => {
     , company_events.company_events_event AS event
     , company_events.company_events_title AS title
     , company_events.company_events_img AS image
+    , company_events.company_events_img_alt AS imageAlt
     FROM company_events
     ORDER BY date ASC`;
 

--- a/utils/helpers/militaryYears.ts
+++ b/utils/helpers/militaryYears.ts
@@ -285,6 +285,7 @@ export const getFrontEvents = (
         description: event.event,
         title: event.title,
         image: event.image,
+        imageAlt: event.imageAlt,
         extraDescription: event.extraDescription,
       };
 


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
Images in the timeline for a tunneller did not have alternative text. This PR adds it.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Add alt for all images in timeline component.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
