### PR TITLE
[NZT-93] Exclude .next/cache from FTP deploy

### DIFF
--- a/.github/workflows/nztunnellers.yml
+++ b/.github/workflows/nztunnellers.yml
@@ -132,6 +132,7 @@ jobs:
             jest.setup.js
             node_modules/**
             playwright.config.js
+            .next/cache/**
 
       - name: Restart server
         run: LANG="en_US.UTF-8" ; ssh -T -p 5022 deploy "source nodevenv/$SERVER_DIR/22/bin/activate && cd $SERVER_DIR && npm ci && touch ~/$SERVER_DIR/tmp/restart.txt"


### PR DESCRIPTION
## Summary
- Adds `.next/cache/**` to the FTP deploy exclude list
- This directory is the webpack/Next.js incremental build cache, used only during `next build` and not needed at runtime on the server
- It changes on every build and was being uploaded/compared on every deploy unnecessarily

## Why
The `deployment` job was taking ~11 minutes, almost entirely due to the FTP sync step. The `.next/cache` directory was being included in the sync despite serving no purpose on the production server.

## Test plan
- [ ] Verify the `deployment` job FTP sync step completes faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)