### PR TITLE
[NZT-97] Fix full search dataset even if the user never typed into the menu

### DIFF
--- a/__tests__/e2e/menu.spec.ts
+++ b/__tests__/e2e/menu.spec.ts
@@ -33,6 +33,28 @@ test("can search for a name", async ({ page }) => {
   ).toBeVisible();
 });
 
+test("search fetches matches from the server route", async ({ page }) => {
+  await page.goto("/");
+
+  const searchRequestPromise = page.waitForRequest((request) => {
+    return (
+      request.url().includes("/api/tunnellers/search?") &&
+      request.method() === "GET"
+    );
+  });
+
+  await Promise.all([
+    searchRequestPromise,
+    page.locator("input").fill("joseph"),
+  ]);
+
+  const request = await searchRequestPromise;
+  expect(request.url()).toContain("query=joseph");
+  expect(request.url()).toContain("locale=en");
+
+  await expect(page.getByLabel("See Joseph Kelly profile")).toBeVisible();
+});
+
 test("can search and click on a name", async ({ page }) => {
   await page.goto("/");
 

--- a/__tests__/unit/components/Menu/Menu.test.tsx
+++ b/__tests__/unit/components/Menu/Menu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { mockTunnellersData } from "__tests__/unit/utils/mocks/mockTunnellers";
 
 import { Menu } from "@/components/Menu/Menu";
@@ -17,10 +17,17 @@ mockedUseRouter.mockReturnValue({
 });
 
 describe("Menu", () => {
+  const fetchMock = jest.fn();
+
   beforeEach(() => {
     mockedUseRouter.mockReturnValue({
       refresh: jest.fn(),
     });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockTunnellersData,
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
   });
 
   afterEach(() => {
@@ -28,13 +35,13 @@ describe("Menu", () => {
   });
 
   test("matches the snapshot", () => {
-    const { asFragment } = render(<Menu tunnellers={mockTunnellersData} />);
+    const { asFragment } = render(<Menu />);
 
     expect(asFragment()).toMatchSnapshot();
   });
 
   test("renders the component correctly", () => {
-    render(<Menu tunnellers={mockTunnellersData} />);
+    render(<Menu />);
 
     const nextButton = screen.getByRole("link", {
       name: "Go to the Homepage",
@@ -46,8 +53,8 @@ describe("Menu", () => {
     expect(search).toHaveAttribute("placeholder", "Search for a Tunneller");
   });
 
-  test("can input a name", () => {
-    render(<Menu tunnellers={mockTunnellersData} />);
+  test("can input a name", async () => {
+    render(<Menu />);
 
     const search = screen.getByRole("textbox");
     fireEvent.click(search);
@@ -55,7 +62,7 @@ describe("Menu", () => {
       target: { value: "John Doe" },
     });
 
-    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(await screen.findByRole("list")).toBeInTheDocument();
     expect(screen.getByText("John")).toBeInTheDocument();
     expect(screen.getByText("Doe")).toBeInTheDocument();
     expect(screen.getByText("Doe")).toHaveClass("surname");
@@ -64,10 +71,14 @@ describe("Menu", () => {
       "href",
       "/tunnellers/test-tunneller--1_234",
     );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/tunnellers/search?query=John%20Doe&locale=en",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   test("becomes invisible on scrolling down", () => {
-    render(<Menu tunnellers={mockTunnellersData} />);
+    render(<Menu />);
     expect(screen.getByTestId("menu")).toHaveClass("menu");
 
     fireEvent.scroll(window, { target: { scrollY: 100 } });
@@ -75,7 +86,7 @@ describe("Menu", () => {
   });
 
   test("becomes visible on scrolling up", () => {
-    render(<Menu tunnellers={mockTunnellersData} />);
+    render(<Menu />);
     expect(screen.getByTestId("menu")).toHaveClass("menu");
 
     fireEvent.scroll(window, { target: { scrollY: 100 } });
@@ -86,23 +97,24 @@ describe("Menu", () => {
   });
 
   describe("Keyboard", () => {
-    test("closes dropdown with Escape key", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("closes dropdown with Escape key", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.change(search, { target: { value: "John Doe" } });
-      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       fireEvent.keyDown(document, { key: "Escape" });
 
       expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
     });
 
-    test("re-opens dropdown with Enter key when results are available", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("re-opens dropdown with Enter key when results are available", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.change(search, { target: { value: "John Doe" } });
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       fireEvent.mouseDown(document.body);
       expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
@@ -114,8 +126,40 @@ describe("Menu", () => {
   });
 
   describe("Dropdown", () => {
-    test("can close the dropdown with outside click", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("keeps previous results visible while the next search is loading", async () => {
+      const secondSearch = Promise.withResolvers<typeof mockTunnellersData>();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTunnellersData,
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => secondSearch.promise,
+      });
+
+      render(<Menu />);
+
+      const search = screen.getByRole("textbox");
+      fireEvent.change(search, {
+        target: { value: "John" },
+      });
+
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
+
+      fireEvent.change(search, {
+        target: { value: "John D" },
+      });
+
+      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(screen.getByText("John")).toBeInTheDocument();
+
+      secondSearch.resolve(mockTunnellersData);
+      await screen.findByTestId("dropdown");
+    });
+
+    test("can close the dropdown with outside click", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -123,14 +167,14 @@ describe("Menu", () => {
         target: { value: "John Doe" },
       });
 
-      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       fireEvent.mouseDown(document.body);
       expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
     });
 
-    test("should not close the dropdown when click on the search bar", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("should not close the dropdown when click on the search bar", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -138,14 +182,14 @@ describe("Menu", () => {
         target: { value: "John Doe" },
       });
 
-      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       fireEvent.mouseDown(search);
       expect(screen.getByTestId("dropdown")).toBeInTheDocument();
     });
 
     test("should not open dropdown if no input", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -153,8 +197,8 @@ describe("Menu", () => {
       expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
     });
 
-    test("should reopen dropdown if input present", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("should reopen dropdown if input present", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -162,7 +206,7 @@ describe("Menu", () => {
         target: { value: "John Doe" },
       });
 
-      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       fireEvent.mouseDown(document.body);
       expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
@@ -171,8 +215,8 @@ describe("Menu", () => {
       expect(screen.getByTestId("dropdown")).toBeInTheDocument();
     });
 
-    test("can click on tunnellers link", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("can click on tunnellers link", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -180,7 +224,7 @@ describe("Menu", () => {
         target: { value: "John Doe" },
       });
 
-      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       const tunnellersLink = screen.getByRole("link", {
         name: "See all Tunnellers →",
@@ -190,8 +234,8 @@ describe("Menu", () => {
       expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
     });
 
-    test("can clear name and close the dropdown", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("can clear name and close the dropdown", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -199,7 +243,7 @@ describe("Menu", () => {
         target: { value: "John Doe" },
       });
 
-      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       fireEvent.click(search);
       fireEvent.change(search, {
@@ -209,7 +253,12 @@ describe("Menu", () => {
     });
 
     test("no dropdown when name not found", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -217,7 +266,9 @@ describe("Menu", () => {
         target: { value: "John Doe Smith" },
       });
 
-      expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
+      return waitFor(() => {
+        expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -235,7 +286,7 @@ describe("Menu", () => {
         writable: true,
       });
 
-      render(<Menu tunnellers={mockTunnellersData} />);
+      render(<Menu />);
 
       expect(mockViewport.addEventListener).toHaveBeenCalledWith(
         "resize",
@@ -251,8 +302,8 @@ describe("Menu", () => {
   });
 
   describe("Clear Button", () => {
-    test("can clear the search input", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("can clear the search input", async () => {
+      render(<Menu />);
 
       const search = screen.getByRole("textbox");
       fireEvent.click(search);
@@ -260,7 +311,7 @@ describe("Menu", () => {
         target: { value: "John Doe" },
       });
 
-      expect(screen.getByTestId("dropdown")).toBeInTheDocument();
+      expect(await screen.findByTestId("dropdown")).toBeInTheDocument();
 
       const clearButton = screen.getByRole("button", {
         name: "Clear search input",
@@ -276,8 +327,8 @@ describe("Menu", () => {
       expect(screen.queryByTestId("dropdown")).not.toBeInTheDocument();
     });
 
-    test("clear button replace magnifier icon", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+    test("clear button replace magnifier icon", async () => {
+      render(<Menu />);
 
       expect(
         screen.getByRole("img", {
@@ -290,6 +341,8 @@ describe("Menu", () => {
       fireEvent.change(search, {
         target: { value: "John Doe" },
       });
+
+      await screen.findByTestId("dropdown");
 
       expect(
         screen.queryByRole("img", {
@@ -304,7 +357,7 @@ describe("Menu", () => {
     });
 
     test("clears the input field and focuses it", () => {
-      render(<Menu tunnellers={mockTunnellersData} />);
+      render(<Menu />);
 
       const input = screen.getByPlaceholderText(
         "Search for a Tunneller",
@@ -329,7 +382,7 @@ describe("Menu", () => {
     test("renders Français link on English locale", () => {
       mockedUseLocale.mockReturnValue("en");
       mockedUsePathname.mockReturnValue("/tunnellers");
-      render(<Menu tunnellers={mockTunnellersData} />);
+      render(<Menu />);
 
       const link = screen.getByRole("link", { name: "Français" });
       expect(link).toBeInTheDocument();
@@ -339,7 +392,7 @@ describe("Menu", () => {
     test("renders English link on French locale", () => {
       mockedUseLocale.mockReturnValue("fr");
       mockedUsePathname.mockReturnValue("/fr/tunnellers");
-      render(<Menu tunnellers={mockTunnellersData} />);
+      render(<Menu />);
 
       const link = screen.getByRole("link", { name: "English" });
       expect(link).toBeInTheDocument();
@@ -349,7 +402,7 @@ describe("Menu", () => {
     test("French switcher falls back to / when path is only /fr", () => {
       mockedUseLocale.mockReturnValue("fr");
       mockedUsePathname.mockReturnValue("/fr");
-      render(<Menu tunnellers={mockTunnellersData} />);
+      render(<Menu />);
 
       const link = screen.getByRole("link", { name: "English" });
       expect(link).toHaveAttribute("href", "/");

--- a/app/api/tunnellers/search/route.ts
+++ b/app/api/tunnellers/search/route.ts
@@ -11,9 +11,8 @@ function isLocale(value: string | null): value is Locale {
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const query = searchParams.get("query")?.trim() ?? "";
-  const locale = isLocale(searchParams.get("locale"))
-    ? searchParams.get("locale")
-    : "en";
+  const requestedLocale = searchParams.get("locale");
+  const locale: Locale = isLocale(requestedLocale) ? requestedLocale : "en";
 
   if (query.length === 0) {
     return NextResponse.json([]);

--- a/app/api/tunnellers/search/route.ts
+++ b/app/api/tunnellers/search/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { Locale } from "@/types/locale";
+import { Tunneller } from "@/types/tunnellers";
+import { getCachedTunnellers } from "@/utils/database/getTunnellers";
+
+function isLocale(value: string | null): value is Locale {
+  return value === "en" || value === "fr";
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const query = searchParams.get("query")?.trim() ?? "";
+  const locale = isLocale(searchParams.get("locale"))
+    ? searchParams.get("locale")
+    : "en";
+
+  if (query.length === 0) {
+    return NextResponse.json([]);
+  }
+
+  const searchParts = query.toLowerCase().split(/\s+/);
+  const grouped = await getCachedTunnellers(locale);
+  const matches = Object.values(grouped)
+    .flat()
+    .filter((tunneller: Tunneller) => {
+      const fullName = tunneller.search.fullName?.toLowerCase() ?? "";
+      return searchParts.every((part) => fullName.includes(part));
+    });
+
+  return NextResponse.json(matches);
+}

--- a/components/Menu/Menu.tsx
+++ b/components/Menu/Menu.tsx
@@ -12,11 +12,7 @@ import { useWindowDimensions } from "@/utils/helpers/useWindowDimensions";
 
 import STYLES from "./Menu.module.scss";
 
-type Props = {
-  tunnellers: Tunneller[];
-};
-
-export function Menu({ tunnellers }: Props) {
+export function Menu() {
   const t = useTranslations("menu");
   const tNav = useTranslations("nav");
   const locale = useLocale();
@@ -29,10 +25,10 @@ export function Menu({ tunnellers }: Props) {
   const divRef = useRef<HTMLDivElement>(null);
   const searchFormRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const prevScrollPosRef = useRef(0);
 
   const router = useRouter();
 
-  const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [menuVisible, setMenuVisible] = useState(true);
   const [filteredTunnellers, setFilteredTunnellers] = useState<Tunneller[]>([]);
   const [dropdownVisible, setDropdownVisible] = useState(false);
@@ -42,13 +38,13 @@ export function Menu({ tunnellers }: Props) {
   useEffect(() => {
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
-      setMenuVisible(prevScrollPos > currentScrollPos);
-      setPrevScrollPos(currentScrollPos);
+      setMenuVisible(prevScrollPosRef.current > currentScrollPos);
+      prevScrollPosRef.current = currentScrollPos;
     };
 
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [prevScrollPos]);
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -94,20 +90,47 @@ export function Menu({ tunnellers }: Props) {
       window.visualViewport?.removeEventListener("resize", handleResize);
   }, []);
 
-  const handleSearch = (search: string) => {
-    const searchParts = search.toLowerCase().split(" ");
+  useEffect(() => {
+    if (query.length === 0) {
+      setFilteredTunnellers([]);
+      setDropdownVisible(false);
+      return;
+    }
 
-    setFilteredTunnellers(
-      search.length > 0
-        ? tunnellers.filter((tunneller: Tunneller) => {
-            const fullName = tunneller.search.fullName?.toLowerCase() ?? "";
-            return searchParts.every((part) => fullName.includes(part));
-          })
-        : [],
-    );
+    let isCancelled = false;
+    const controller = new AbortController();
 
-    setDropdownVisible(search.length > 0);
-  };
+    setDropdownVisible(true);
+
+    const searchTunnellers = async () => {
+      try {
+        const response = await fetch(
+          `/api/tunnellers/search?query=${encodeURIComponent(query)}&locale=${locale}`,
+          { signal: controller.signal },
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to search tunnellers");
+        }
+
+        const tunnellers: Tunneller[] = await response.json();
+        if (!isCancelled) {
+          setFilteredTunnellers(tunnellers);
+        }
+      } catch {
+        if (!controller.signal.aborted && !isCancelled) {
+          setFilteredTunnellers([]);
+        }
+      }
+    };
+
+    void searchTunnellers();
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+  }, [locale, query]);
 
   const handleClickInside = () => {
     if (!dropdownVisible) {
@@ -165,9 +188,7 @@ export function Menu({ tunnellers }: Props) {
             placeholder={t("searchPlaceholder")}
             value={query}
             onChange={(event) => {
-              const value = event.target.value;
-              setQuery(value);
-              handleSearch(value);
+              setQuery(event.target.value);
             }}
           />
 

--- a/components/Menu/MenuContainer.tsx
+++ b/components/Menu/MenuContainer.tsx
@@ -1,13 +1,5 @@
-import { getLocale } from "next-intl/server";
-
 import { Menu } from "@/components/Menu/Menu";
-import { Locale } from "@/types/locale";
-import { getCachedTunnellers } from "@/utils/database/getTunnellers";
 
-export async function MenuContainer() {
-  const locale = (await getLocale()) as Locale;
-  const grouped = await getCachedTunnellers(locale);
-  const tunnellers = Object.values(grouped).flat();
-
-  return <Menu tunnellers={tunnellers} />;
+export function MenuContainer() {
+  return <Menu />;
 }


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
The original problem was:

  - app/[locale]/layout.tsx:1 always renders the menu
  - components/Menu/MenuContainer.tsx:1 was loading all tunnellers on every page
  - components/Menu/Menu.tsx:1 was filtering that whole dataset client-side

  So every route was paying the cost of shipping the full search dataset, even if the user never typed into the menu.

  What we changed:

  - moved search to a server route: app/api/tunnellers/search/route.ts:1
  - stopped passing the full tunneller list through the layout
  - kept your preferred UX:
      - search starts from the first character
      - results are not capped
  - then fixed the follow-up regression where the dropdown flickered between keystrokes because results were being cleared before each response returned

  So the goal was performance/architecture, and the flicker fix was a regression from that refactor.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Fix full search dataset even if the user never typed into the menu

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
