### PR TITLE
[NZT-107] Fix dialog height for desktop

### DIFF
--- a/components/Dialog/Dialog.module.scss
+++ b/components/Dialog/Dialog.module.scss
@@ -35,6 +35,11 @@
     border-radius: variables.$border-radius;
     border: 1px solid variables.$primary-light-color;
   }
+
+  @include variables.desktop {
+    height: 80vh;
+    max-height: fit-content;
+  }
 }
 
 .dialog::backdrop {


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
Dialog height was not set and it was not fitting its content

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Fix dialog height for desktop.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
