### PR TITLE
[NZT-112] Simplify route data loading and database connection handling

### DIFF
--- a/__tests__/unit/utils/database/getTunneller.test.ts
+++ b/__tests__/unit/utils/database/getTunneller.test.ts
@@ -1,0 +1,138 @@
+import { getTunneller } from "@/utils/database/getTunneller";
+import { armyExperienceQuery } from "@/utils/database/queries/armyExperienceQuery";
+import { companyEventsQuery } from "@/utils/database/queries/companyEventsQuery";
+import { imageSourceBookAuthorsQuery } from "@/utils/database/queries/imageSourceBookAuthorsQuery";
+import { londonGazetteQuery } from "@/utils/database/queries/londonGazetteQuery";
+import { medalsQuery } from "@/utils/database/queries/medalsQuery";
+import { nzArchivesQuery } from "@/utils/database/queries/nzArchivesQuery";
+import { tunnellerEventsQuery } from "@/utils/database/queries/tunnellerEventsQuery";
+import { tunnellerQuery } from "@/utils/database/queries/tunnellerQuery";
+
+jest.mock("@/utils/database/queries/tunnellerQuery");
+jest.mock("@/utils/database/queries/armyExperienceQuery");
+jest.mock("@/utils/database/queries/companyEventsQuery");
+jest.mock("@/utils/database/queries/tunnellerEventsQuery");
+jest.mock("@/utils/database/queries/medalsQuery");
+jest.mock("@/utils/database/queries/nzArchivesQuery");
+jest.mock("@/utils/database/queries/londonGazetteQuery");
+jest.mock("@/utils/database/queries/imageSourceBookAuthorsQuery");
+
+describe("getTunneller", () => {
+  test("returns a plain tunneller profile object", async () => {
+    const mockConnection = {};
+
+    (tunnellerQuery as jest.Mock).mockResolvedValue({
+      id: 1,
+      slug: "john-doe--1",
+      serial: "1234",
+      forename: "John",
+      surname: "Doe",
+      birth_date: "1890-01-01",
+      death_date: null,
+      birth_country: "New Zealand",
+      mother_name: null,
+      mother_origin: null,
+      father_name: null,
+      father_origin: null,
+      marital_status: null,
+      spouse: null,
+      work: null,
+      employer: null,
+      residence: null,
+      hometown: null,
+      wife_name: null,
+      father: null,
+      mother: null,
+      enlistment_date: "1915-01-01",
+      training_start: "1915-01-03",
+      training_location: null,
+      training_location_type: null,
+      embarkation_unit: null,
+      embarkation_unit_key: null,
+      section: null,
+      attached_corps: null,
+      embarkation_date: null,
+      embarkation_ref: null,
+      embarkation_vessel: null,
+      posted_date: "1915-01-02",
+      posted_from_corps: null,
+      posted_unit: null,
+      posted_unit_key: null,
+      transferred_to_date: null,
+      transferred_to_unit: null,
+      transport_uk_start: "1915-02-01",
+      transport_uk_ref: null,
+      transport_uk_vessel: null,
+      transport_nz_start: null,
+      transport_nz_ref: null,
+      transport_nz_vessel: null,
+      demobilization_date: null,
+      discharge_uk: null,
+      has_deserted: 0,
+      death_type: null,
+      death_type_key: null,
+      death_location: null,
+      death_town: null,
+      death_country: null,
+      death_cause: null,
+      death_cause_key: null,
+      death_circumstances: null,
+      cemetery: null,
+      cemetery_town: null,
+      cemetery_country: null,
+      grave: null,
+      birth_location: null,
+      birth_town: null,
+      district: null,
+      aka: null,
+      nz_arrival_year: null,
+      nz_arrival_age: null,
+      father_country: null,
+      mother_country: null,
+      image: null,
+      image_url: null,
+      image_source_type: null,
+      family_name: null,
+      newspaper_name: null,
+      newspaper_date: null,
+      book_title: null,
+      book_town: null,
+      book_publisher: null,
+      book_year: null,
+      book_page: null,
+      rank: "Sapper",
+      unit: "New Zealand Tunnelling Company",
+      corps: "Tunnellers",
+      corps_key: "Tunnellers",
+      death_age: null,
+      awmm_cenotaph: null,
+    });
+
+    (armyExperienceQuery as jest.Mock).mockResolvedValue([]);
+    (companyEventsQuery as jest.Mock).mockResolvedValue([]);
+    (tunnellerEventsQuery as jest.Mock).mockResolvedValue([]);
+    (medalsQuery as jest.Mock).mockResolvedValue([]);
+    (nzArchivesQuery as jest.Mock).mockResolvedValue([]);
+    (londonGazetteQuery as jest.Mock).mockResolvedValue([]);
+    (imageSourceBookAuthorsQuery as jest.Mock).mockResolvedValue([]);
+
+    // @ts-expect-error mocked connection
+    const tunneller = await getTunneller("john-doe--1", "en", mockConnection);
+
+    expect(tunneller).toMatchObject({
+      id: 1,
+      slug: "john-doe--1",
+      summary: {
+        name: {
+          forename: "John",
+          surname: "Doe",
+        },
+      },
+      militaryYears: {
+        enlistment: {
+          rank: "Sapper",
+        },
+      },
+    });
+  });
+});

--- a/__tests__/unit/utils/database/getTunnellerBySlug.test.ts
+++ b/__tests__/unit/utils/database/getTunnellerBySlug.test.ts
@@ -1,0 +1,90 @@
+import { redirect } from "next/navigation";
+
+import { getTunneller } from "@/utils/database/getTunneller";
+import { getTunnellerBySlug } from "@/utils/database/getTunnellerBySlug";
+import { tunnellerSlugByIdQuery } from "@/utils/database/queries/tunnellerSlugByIdQuery";
+import { withConnection } from "@/utils/database/withConnection";
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+}));
+
+jest.mock("@/utils/database/getTunneller");
+jest.mock("@/utils/database/queries/tunnellerSlugByIdQuery");
+jest.mock("@/utils/database/withConnection");
+
+describe("getTunnellerBySlug", () => {
+  const mockConnection = {};
+  const mockRedirect = jest.mocked(redirect);
+  const mockGetTunneller = jest.mocked(getTunneller);
+  const mockTunnellerSlugByIdQuery = jest.mocked(tunnellerSlugByIdQuery);
+  const mockWithConnection = jest.mocked(withConnection);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWithConnection.mockImplementation(async (callback) =>
+      callback(mockConnection),
+    );
+  });
+
+  test("redirects numeric slugs to the profile route", async () => {
+    mockTunnellerSlugByIdQuery.mockResolvedValue("john-doe--1");
+    mockRedirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    await expect(getTunnellerBySlug("1", "en")).rejects.toThrow(
+      "NEXT_REDIRECT",
+    );
+
+    expect(mockTunnellerSlugByIdQuery).toHaveBeenCalledWith(
+      "1",
+      mockConnection,
+    );
+    expect(mockRedirect).toHaveBeenCalledWith("/tunnellers/john-doe--1");
+    expect(mockGetTunneller).not.toHaveBeenCalled();
+  });
+
+  test("redirects numeric slugs to the timeline route", async () => {
+    mockTunnellerSlugByIdQuery.mockResolvedValue("john-doe--1");
+    mockRedirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    await expect(getTunnellerBySlug("1", "fr", "timeline")).rejects.toThrow(
+      "NEXT_REDIRECT",
+    );
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "/fr/tunnellers/john-doe--1/wwi-timeline",
+    );
+    expect(mockGetTunneller).not.toHaveBeenCalled();
+  });
+
+  test("returns tunneller data for non-numeric slugs", async () => {
+    const tunneller = { slug: "john-doe--1" };
+    mockGetTunneller.mockResolvedValue(tunneller as never);
+
+    await expect(getTunnellerBySlug("john-doe--1", "en")).resolves.toBe(
+      tunneller,
+    );
+
+    expect(mockTunnellerSlugByIdQuery).not.toHaveBeenCalled();
+    expect(mockGetTunneller).toHaveBeenCalledWith(
+      "john-doe--1",
+      "en",
+      mockConnection,
+    );
+  });
+
+  test("falls through to getTunneller when numeric slug lookup misses", async () => {
+    const tunneller = { slug: "1" };
+    mockTunnellerSlugByIdQuery.mockResolvedValue(null);
+    mockGetTunneller.mockResolvedValue(tunneller as never);
+
+    await expect(getTunnellerBySlug("1", "en")).resolves.toBe(tunneller);
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(mockGetTunneller).toHaveBeenCalledWith("1", "en", mockConnection);
+  });
+});

--- a/__tests__/unit/utils/database/getTunnellers.test.ts
+++ b/__tests__/unit/utils/database/getTunnellers.test.ts
@@ -1,5 +1,3 @@
-import { NextResponse } from "next/server";
-
 import { Tunneller, TunnellerData } from "@/types/tunnellers";
 import { getTunnellers } from "@/utils/database/getTunnellers";
 import { rollQuery } from "@/utils/database/queries/rollQuery";
@@ -9,12 +7,6 @@ jest.mock("next/cache", () => ({
 }));
 
 jest.mock("@/utils/database/queries/rollQuery");
-
-jest.mock("next/server", () => ({
-  NextResponse: {
-    json: jest.fn((data) => data),
-  },
-}));
 
 describe("getTunnellers", () => {
   test("should return a list of tunnellers with full names", async () => {
@@ -108,6 +100,6 @@ describe("getTunnellers", () => {
       },
     ];
 
-    expect(response).toEqual(NextResponse.json(expectedTunnellers));
+    expect(response).toEqual(expectedTunnellers);
   });
 });

--- a/__tests__/unit/utils/database/withConnection.test.ts
+++ b/__tests__/unit/utils/database/withConnection.test.ts
@@ -1,0 +1,44 @@
+import { mysqlConnection } from "@/utils/database/mysqlConnection";
+import { withConnection } from "@/utils/database/withConnection";
+
+jest.mock("@/utils/database/mysqlConnection", () => ({
+  mysqlConnection: {
+    getConnection: jest.fn(),
+  },
+}));
+
+describe("withConnection", () => {
+  const mockGetConnection = jest.mocked(mysqlConnection.getConnection);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns the callback result and releases the connection", async () => {
+    const release = jest.fn();
+    const connection = { release };
+    mockGetConnection.mockResolvedValue(connection as never);
+
+    const result = await withConnection(async (receivedConnection) => {
+      expect(receivedConnection).toBe(connection);
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  test("releases the connection when the callback throws", async () => {
+    const release = jest.fn();
+    const connection = { release };
+    mockGetConnection.mockResolvedValue(connection as never);
+
+    await expect(
+      withConnection(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/[locale]/about-us/page.tsx
+++ b/app/[locale]/about-us/page.tsx
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { getTranslations } from "next-intl/server";
 
 import { AboutUs } from "@/components/AboutUs/AboutUs";
@@ -9,12 +8,12 @@ import {
   ImageData,
 } from "@/types/article";
 import { Locale } from "@/types/locale";
-import { mysqlConnection } from "@/utils/database/mysqlConnection";
 import {
   aboutUsTitle,
   aboutUsSections,
   aboutUsImage,
 } from "@/utils/database/queries/aboutUsQuery";
+import { withConnection } from "@/utils/database/withConnection";
 import { buildPageMetadata } from "@/utils/helpers/metadata";
 
 type Props = {
@@ -22,26 +21,24 @@ type Props = {
 };
 
 async function getData(locale: Locale) {
-  const connection = await mysqlConnection.getConnection();
-
   try {
-    const data: AboutUsData = await aboutUsTitle(locale, connection);
-    const sections: SectionData[] = await aboutUsSections(locale, connection);
-    const images: ImageData[] = await aboutUsImage(locale, connection);
+    return await withConnection(async (connection) => {
+      const data: AboutUsData = await aboutUsTitle(locale, connection);
+      const sections: SectionData[] = await aboutUsSections(locale, connection);
+      const images: ImageData[] = await aboutUsImage(locale, connection);
 
-    const article: AboutUsArticle = {
-      id: data.id,
-      title: data.title,
-      section: sections,
-      image: images,
-    };
+      const article: AboutUsArticle = {
+        id: data.id,
+        title: data.title,
+        section: sections,
+        image: images,
+      };
 
-    return NextResponse.json(article);
+      return article;
+    });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to fetch About Us data: ${errorMessage}`);
-  } finally {
-    connection.release();
   }
 }
 
@@ -61,8 +58,7 @@ export async function generateMetadata(props: Props) {
 
 export default async function Page(props: Props) {
   const { locale } = await props.params;
-  const response = await getData(locale);
-  const article: AboutUsArticle = await response.json();
+  const article: AboutUsArticle = await getData(locale);
 
   return <AboutUs article={article} />;
 }

--- a/app/[locale]/history/[id]/page.tsx
+++ b/app/[locale]/history/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { Article } from "@/components/Article/Article";
@@ -10,7 +9,6 @@ import {
   ImageData,
 } from "@/types/article";
 import { Locale } from "@/types/locale";
-import { mysqlConnection } from "@/utils/database/mysqlConnection";
 import {
   allArticleIdsQuery,
   chapterQuery,
@@ -18,6 +16,7 @@ import {
   imagesQuery,
   nextArticleQuery,
 } from "@/utils/database/queries/historyChapterQuery";
+import { withConnection } from "@/utils/database/withConnection";
 import { getNextChapter } from "@/utils/helpers/article";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
@@ -26,50 +25,48 @@ type Props = {
 };
 
 async function getData(id: string, locale: Locale) {
-  const connection = await mysqlConnection.getConnection();
-
   try {
-    const data: ArticleData = await chapterQuery(id, locale, connection);
-    const section: SectionData[] = await sectionsQuery(id, locale, connection);
-    const images: ImageData[] = await imagesQuery(id, locale, connection);
-    const nextArticle: ArticleReferenceData[] = await nextArticleQuery(
-      locale,
-      connection,
-    );
+    return await withConnection(async (connection) => {
+      const data: ArticleData = await chapterQuery(id, locale, connection);
+      const section: SectionData[] = await sectionsQuery(
+        id,
+        locale,
+        connection,
+      );
+      const images: ImageData[] = await imagesQuery(id, locale, connection);
+      const nextArticle: ArticleReferenceData[] = await nextArticleQuery(
+        locale,
+        connection,
+      );
 
-    const article: Chapter = {
-      id: data.id,
-      chapter: data.chapter,
-      title: data.title,
-      section: section,
-      image: images,
-      next: getNextChapter(data.chapter, nextArticle),
-      notes: data.notes,
-    };
+      const article: Chapter = {
+        id: data.id,
+        chapter: data.chapter,
+        title: data.title,
+        section: section,
+        image: images,
+        next: getNextChapter(data.chapter, nextArticle),
+        notes: data.notes,
+      };
 
-    return NextResponse.json(article);
+      return article;
+    });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to fetch Chapter data: ${errorMessage}`);
-  } finally {
-    connection.release();
   }
 }
 
 export async function generateStaticParams() {
-  const connection = await mysqlConnection.getConnection();
-  try {
-    const ids = await allArticleIdsQuery(connection);
-    return ids.map((id) => ({ id }));
-  } finally {
-    connection.release();
-  }
+  const ids = await withConnection((connection) =>
+    allArticleIdsQuery(connection),
+  );
+  return ids.map((id) => ({ id }));
 }
 
 export async function generateMetadata(props: Props) {
   const { id, locale } = await props.params;
-  const response = await getData(id, locale);
-  const article: Chapter = await response.json();
+  const article: Chapter = await getData(id, locale);
 
   const t = await getTranslations({ locale, namespace: "site" });
   const chapterTitle = article.title.replace(/\\/g, " ");
@@ -88,8 +85,7 @@ export async function generateMetadata(props: Props) {
 export default async function Page(props: Props) {
   const { id, locale } = await props.params;
   setRequestLocale(locale);
-  const response = await getData(id, locale);
-  const article: Chapter = await response.json();
+  const article: Chapter = await getData(id, locale);
 
   const jsonLd = {
     "@context": "https://schema.org",

--- a/app/[locale]/maps/tunnellers-works/page.tsx
+++ b/app/[locale]/maps/tunnellers-works/page.tsx
@@ -1,10 +1,8 @@
-import { NextResponse } from "next/server";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Suspense } from "react";
 
 import { WorksMapContainer } from "@/components/WorksMap/WorksMapContainer";
 import { Locale } from "@/types/locale";
-import { mysqlConnection } from "@/utils/database/mysqlConnection";
 import {
   cavesQuery,
   cavePathsQuery,
@@ -29,6 +27,7 @@ import {
   WorkData,
   WorkPathPoint,
 } from "@/utils/database/queries/worksQuery";
+import { withConnection } from "@/utils/database/withConnection";
 import { buildPageMetadata } from "@/utils/helpers/metadata";
 
 type Props = {
@@ -36,31 +35,30 @@ type Props = {
 };
 
 async function getData() {
-  const connection = await mysqlConnection.getConnection();
   try {
-    const works = await worksQuery(connection);
-    const paths = await workPathsQuery(connection);
-    const caves = await cavesQuery(connection);
-    const cavePaths = await cavePathsQuery(connection);
-    const subways = await subwaysQuery(connection);
-    const subwayPaths = await subwayPathsQuery(connection);
-    const frontLines = await frontLinesQuery(connection);
-    const frontLinePaths = await frontLinePathsQuery(connection);
-    return NextResponse.json({
-      works,
-      paths,
-      caves,
-      cavePaths,
-      subways,
-      subwayPaths,
-      frontLines,
-      frontLinePaths,
+    return await withConnection(async (connection) => {
+      const works = await worksQuery(connection);
+      const paths = await workPathsQuery(connection);
+      const caves = await cavesQuery(connection);
+      const cavePaths = await cavePathsQuery(connection);
+      const subways = await subwaysQuery(connection);
+      const subwayPaths = await subwayPathsQuery(connection);
+      const frontLines = await frontLinesQuery(connection);
+      const frontLinePaths = await frontLinePathsQuery(connection);
+      return {
+        works,
+        paths,
+        caves,
+        cavePaths,
+        subways,
+        subwayPaths,
+        frontLines,
+        frontLinePaths,
+      };
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to fetch works data: ${errorMessage}`);
-  } finally {
-    connection.release();
   }
 }
 
@@ -81,7 +79,6 @@ export default async function Page({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const response = await getData();
   const {
     works,
     paths,
@@ -100,7 +97,7 @@ export default async function Page({ params }: Props) {
     subwayPaths: SubwayPathPoint[];
     frontLines: FrontLineData[];
     frontLinePaths: FrontLinePathPoint[];
-  } = await response.json();
+  } = await getData();
 
   return (
     <Suspense fallback={<div style={{ minHeight: "100vh" }} />}>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,14 +1,13 @@
-import { NextResponse } from "next/server";
 import { getTranslations } from "next-intl/server";
 
 import { HomePage } from "@/components/HomePage/HomePage";
 import { HistoryImageChapters, HistoryChapterData } from "@/types/homepage";
 import { Locale } from "@/types/locale";
-import { mysqlConnection } from "@/utils/database/mysqlConnection";
 import {
   historyImageChaptersQuery,
   historyChaptersQuery,
 } from "@/utils/database/queries/homepageQuery";
+import { withConnection } from "@/utils/database/withConnection";
 import { getHistoryChapters } from "@/utils/helpers/homepage";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
@@ -29,36 +28,31 @@ export async function generateMetadata({ params }: Props) {
 }
 
 async function getData(locale: Locale) {
-  const connection = await mysqlConnection.getConnection();
-
   try {
-    const historyImageChapters: HistoryImageChapters[] =
-      await historyImageChaptersQuery(connection);
-    const historyChapters: HistoryChapterData[] = await historyChaptersQuery(
-      locale,
-      connection,
-    );
+    return await withConnection(async (connection) => {
+      const historyImageChapters: HistoryImageChapters[] =
+        await historyImageChaptersQuery(connection);
+      const historyChapters: HistoryChapterData[] = await historyChaptersQuery(
+        locale,
+        connection,
+      );
 
-    const homepage = {
-      historyChapters: getHistoryChapters(
-        historyChapters,
-        historyImageChapters,
-      ),
-    };
-
-    return NextResponse.json(homepage);
+      return {
+        historyChapters: getHistoryChapters(
+          historyChapters,
+          historyImageChapters,
+        ),
+      };
+    });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to fetch Homepage data: ${errorMessage}`);
-  } finally {
-    connection.release();
   }
 }
 
 export default async function Page(props: Props) {
   const { locale } = await props.params;
-  const response = await getData(locale);
-  const homepage = await response.json();
+  const homepage = await getData(locale);
 
   const jsonLd = {
     "@context": "https://schema.org",

--- a/app/[locale]/tunnellers/[slug]/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/page.tsx
@@ -5,8 +5,8 @@ import { Profile } from "@/components/Profile/Profile";
 import { Locale } from "@/types/locale";
 import { TunnellerProfile } from "@/types/tunneller";
 import { getTunneller } from "@/utils/database/getTunneller";
-import { mysqlConnection } from "@/utils/database/mysqlConnection";
 import { tunnellerSlugByIdQuery } from "@/utils/database/queries/tunnellerSlugByIdQuery";
+import { withConnection } from "@/utils/database/withConnection";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 type Props = {
@@ -14,33 +14,30 @@ type Props = {
 };
 
 async function getData(slug: string, locale: Locale) {
-  const connection = await mysqlConnection.getConnection();
-
   try {
-    if (/^\d+$/.test(slug)) {
-      const newSlug = await tunnellerSlugByIdQuery(slug, connection);
-      if (newSlug) {
-        const localePrefix = locale === "en" ? "" : `/${locale}`;
-        redirect(`${localePrefix}/tunnellers/${newSlug}`);
+    return await withConnection(async (connection) => {
+      if (/^\d+$/.test(slug)) {
+        const newSlug = await tunnellerSlugByIdQuery(slug, connection);
+        if (newSlug) {
+          const localePrefix = locale === "en" ? "" : `/${locale}`;
+          redirect(`${localePrefix}/tunnellers/${newSlug}`);
+        }
       }
-    }
 
-    return getTunneller(slug, locale, connection);
+      return getTunneller(slug, locale, connection);
+    });
   } catch (error) {
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
       throw error;
     }
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to fetch Tunneller data: ${errorMessage}`);
-  } finally {
-    connection.release();
   }
 }
 
 export async function generateMetadata(props: Props) {
   const { slug, locale } = await props.params;
-  const response = await getData(slug, locale);
-  const tunneller: TunnellerProfile = await response.json();
+  const tunneller: TunnellerProfile = await getData(slug, locale);
 
   const surname = tunneller.summary.name.surname;
   const forename = tunneller.summary.name.forename;
@@ -62,8 +59,7 @@ export async function generateMetadata(props: Props) {
 
 export default async function Page(props: Props) {
   const { slug, locale } = await props.params;
-  const response = await getData(slug, locale);
-  const tunneller: TunnellerProfile = await response.json();
+  const tunneller: TunnellerProfile = await getData(slug, locale);
 
   const { forename, surname } = tunneller.summary.name;
   const rank = tunneller.militaryYears.enlistment.rank;

--- a/app/[locale]/tunnellers/[slug]/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/page.tsx
@@ -1,43 +1,18 @@
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
 import { Profile } from "@/components/Profile/Profile";
 import { Locale } from "@/types/locale";
 import { TunnellerProfile } from "@/types/tunneller";
-import { getTunneller } from "@/utils/database/getTunneller";
-import { tunnellerSlugByIdQuery } from "@/utils/database/queries/tunnellerSlugByIdQuery";
-import { withConnection } from "@/utils/database/withConnection";
+import { getTunnellerBySlug } from "@/utils/database/getTunnellerBySlug";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 type Props = {
   params: Promise<{ slug: string; locale: Locale }>;
 };
 
-async function getData(slug: string, locale: Locale) {
-  try {
-    return await withConnection(async (connection) => {
-      if (/^\d+$/.test(slug)) {
-        const newSlug = await tunnellerSlugByIdQuery(slug, connection);
-        if (newSlug) {
-          const localePrefix = locale === "en" ? "" : `/${locale}`;
-          redirect(`${localePrefix}/tunnellers/${newSlug}`);
-        }
-      }
-
-      return getTunneller(slug, locale, connection);
-    });
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
-      throw error;
-    }
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to fetch Tunneller data: ${errorMessage}`);
-  }
-}
-
 export async function generateMetadata(props: Props) {
   const { slug, locale } = await props.params;
-  const tunneller: TunnellerProfile = await getData(slug, locale);
+  const tunneller: TunnellerProfile = await getTunnellerBySlug(slug, locale);
 
   const surname = tunneller.summary.name.surname;
   const forename = tunneller.summary.name.forename;
@@ -59,7 +34,7 @@ export async function generateMetadata(props: Props) {
 
 export default async function Page(props: Props) {
   const { slug, locale } = await props.params;
-  const tunneller: TunnellerProfile = await getData(slug, locale);
+  const tunneller: TunnellerProfile = await getTunnellerBySlug(slug, locale);
 
   const { forename, surname } = tunneller.summary.name;
   const rank = tunneller.militaryYears.enlistment.rank;

--- a/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
@@ -5,8 +5,8 @@ import { Timeline } from "@/components/Timeline/Timeline";
 import { Locale } from "@/types/locale";
 import { TunnellerProfile } from "@/types/tunneller";
 import { getTunneller } from "@/utils/database/getTunneller";
-import { mysqlConnection } from "@/utils/database/mysqlConnection";
 import { tunnellerSlugByIdQuery } from "@/utils/database/queries/tunnellerSlugByIdQuery";
+import { withConnection } from "@/utils/database/withConnection";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 type Props = {
@@ -14,33 +14,30 @@ type Props = {
 };
 
 async function getData(slug: string, locale: Locale) {
-  const connection = await mysqlConnection.getConnection();
-
   try {
-    if (/^\d+$/.test(slug)) {
-      const newSlug = await tunnellerSlugByIdQuery(slug, connection);
-      if (newSlug) {
-        const localePrefix = locale === "en" ? "" : `/${locale}`;
-        redirect(`${localePrefix}/tunnellers/${newSlug}/wwi-timeline`);
+    return await withConnection(async (connection) => {
+      if (/^\d+$/.test(slug)) {
+        const newSlug = await tunnellerSlugByIdQuery(slug, connection);
+        if (newSlug) {
+          const localePrefix = locale === "en" ? "" : `/${locale}`;
+          redirect(`${localePrefix}/tunnellers/${newSlug}/wwi-timeline`);
+        }
       }
-    }
 
-    return getTunneller(slug, locale, connection);
+      return getTunneller(slug, locale, connection);
+    });
   } catch (error) {
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
       throw error;
     }
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to fetch Timeline data: ${errorMessage}`);
-  } finally {
-    connection.release();
   }
 }
 
 export async function generateMetadata(props: Props) {
   const { slug, locale } = await props.params;
-  const response = await getData(slug, locale);
-  const tunneller: TunnellerProfile = await response.json();
+  const tunneller: TunnellerProfile = await getData(slug, locale);
 
   const surname = tunneller.summary.name.surname;
   const forename = tunneller.summary.name.forename;
@@ -67,8 +64,7 @@ export async function generateMetadata(props: Props) {
 
 export default async function Page(props: Props) {
   const { slug, locale } = await props.params;
-  const response = await getData(slug, locale);
-  const tunneller: TunnellerProfile = await response.json();
+  const tunneller: TunnellerProfile = await getData(slug, locale);
 
   const { forename, surname } = tunneller.summary.name;
   const rank = tunneller.militaryYears.enlistment.rank;

--- a/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
@@ -1,43 +1,22 @@
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
 import { Timeline } from "@/components/Timeline/Timeline";
 import { Locale } from "@/types/locale";
 import { TunnellerProfile } from "@/types/tunneller";
-import { getTunneller } from "@/utils/database/getTunneller";
-import { tunnellerSlugByIdQuery } from "@/utils/database/queries/tunnellerSlugByIdQuery";
-import { withConnection } from "@/utils/database/withConnection";
+import { getTunnellerBySlug } from "@/utils/database/getTunnellerBySlug";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 type Props = {
   params: Promise<{ slug: string; locale: Locale }>;
 };
 
-async function getData(slug: string, locale: Locale) {
-  try {
-    return await withConnection(async (connection) => {
-      if (/^\d+$/.test(slug)) {
-        const newSlug = await tunnellerSlugByIdQuery(slug, connection);
-        if (newSlug) {
-          const localePrefix = locale === "en" ? "" : `/${locale}`;
-          redirect(`${localePrefix}/tunnellers/${newSlug}/wwi-timeline`);
-        }
-      }
-
-      return getTunneller(slug, locale, connection);
-    });
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
-      throw error;
-    }
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to fetch Timeline data: ${errorMessage}`);
-  }
-}
-
 export async function generateMetadata(props: Props) {
   const { slug, locale } = await props.params;
-  const tunneller: TunnellerProfile = await getData(slug, locale);
+  const tunneller: TunnellerProfile = await getTunnellerBySlug(
+    slug,
+    locale,
+    "timeline",
+  );
 
   const surname = tunneller.summary.name.surname;
   const forename = tunneller.summary.name.forename;
@@ -64,7 +43,11 @@ export async function generateMetadata(props: Props) {
 
 export default async function Page(props: Props) {
   const { slug, locale } = await props.params;
-  const tunneller: TunnellerProfile = await getData(slug, locale);
+  const tunneller: TunnellerProfile = await getTunnellerBySlug(
+    slug,
+    locale,
+    "timeline",
+  );
 
   const { forename, surname } = tunneller.summary.name;
   const rank = tunneller.militaryYears.enlistment.rank;

--- a/utils/database/getTunneller.ts
+++ b/utils/database/getTunneller.ts
@@ -1,5 +1,4 @@
 import { PoolConnection } from "mysql2/promise";
-import { NextResponse } from "next/server";
 
 import { Locale } from "@/types/locale";
 import {
@@ -351,5 +350,5 @@ export async function getTunneller(
     ),
   };
 
-  return NextResponse.json(tunneller);
+  return tunneller;
 }

--- a/utils/database/getTunnellerBySlug.ts
+++ b/utils/database/getTunnellerBySlug.ts
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+
+import { Locale } from "@/types/locale";
+
+import { getTunneller } from "./getTunneller";
+import { tunnellerSlugByIdQuery } from "./queries/tunnellerSlugByIdQuery";
+import { withConnection } from "./withConnection";
+
+type RedirectTarget = "profile" | "timeline";
+
+export async function getTunnellerBySlug(
+  slug: string,
+  locale: Locale,
+  redirectTarget: RedirectTarget = "profile",
+) {
+  try {
+    return await withConnection(async (connection) => {
+      if (/^\d+$/.test(slug)) {
+        const newSlug = await tunnellerSlugByIdQuery(slug, connection);
+        if (newSlug) {
+          const localePrefix = locale === "en" ? "" : `/${locale}`;
+          const suffix = redirectTarget === "timeline" ? "/wwi-timeline" : "";
+          redirect(`${localePrefix}/tunnellers/${newSlug}${suffix}`);
+        }
+      }
+
+      return getTunneller(slug, locale, connection);
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
+      throw error;
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const context =
+      redirectTarget === "timeline" ? "Timeline data" : "Tunneller data";
+    throw new Error(`Failed to fetch ${context}: ${errorMessage}`);
+  }
+}

--- a/utils/database/getTunnellers.ts
+++ b/utils/database/getTunnellers.ts
@@ -1,12 +1,11 @@
 import { PoolConnection } from "mysql2/promise";
 import { unstable_cache } from "next/cache";
-import { NextResponse } from "next/server";
 
 import { Locale } from "@/types/locale";
 import { Tunneller, TunnellerData } from "@/types/tunnellers";
 
-import { mysqlConnection } from "./mysqlConnection";
 import { rollQuery } from "./queries/rollQuery";
+import { withConnection } from "./withConnection";
 
 export async function getTunnellers(
   locale: Locale,
@@ -37,28 +36,24 @@ export async function getTunnellers(
     corpsId: result.corps_id,
   }));
 
-  return NextResponse.json(tunnellers);
+  return tunnellers;
 }
 
 export const getCachedTunnellers = unstable_cache(
   async (locale: Locale): Promise<Record<string, Tunneller[]>> => {
-    const connection = await mysqlConnection.getConnection();
-    try {
-      const response = await getTunnellers(locale, connection);
-      const data: Tunneller[] = await response.json();
+    const data = await withConnection((connection) =>
+      getTunnellers(locale, connection),
+    );
 
-      return data.reduce(
-        (acc: Record<string, Tunneller[]>, tunneller: Tunneller) => {
-          const firstLetter = tunneller.name.surname.charAt(0).toUpperCase();
-          if (!acc[firstLetter]) acc[firstLetter] = [];
-          acc[firstLetter].push(tunneller);
-          return acc;
-        },
-        {},
-      );
-    } finally {
-      connection.release();
-    }
+    return data.reduce(
+      (acc: Record<string, Tunneller[]>, tunneller: Tunneller) => {
+        const firstLetter = tunneller.name.surname.charAt(0).toUpperCase();
+        if (!acc[firstLetter]) acc[firstLetter] = [];
+        acc[firstLetter].push(tunneller);
+        return acc;
+      },
+      {},
+    );
   },
   ["tunnellers"],
   { revalidate: false },

--- a/utils/database/withConnection.ts
+++ b/utils/database/withConnection.ts
@@ -1,0 +1,15 @@
+import { PoolConnection } from "mysql2/promise";
+
+import { mysqlConnection } from "./mysqlConnection";
+
+export async function withConnection<T>(
+  callback: (_connection: PoolConnection) => Promise<T>,
+): Promise<T> {
+  const connection = await mysqlConnection.getConnection();
+
+  try {
+    return await callback(connection);
+  } finally {
+    connection.release();
+  }
+}


### PR DESCRIPTION
## What prompted this change?

This PR simplifies route-level data loading by centralizing database connection handling and removing repeated loader logic in page routes.

Several route files repeated the same patterns:
- opening and releasing DB connections
- wrapping internal data in HTTP-style responses only to parse them again immediately
- duplicating tunneller slug redirect and fetch logic across profile and timeline routes

This refactor reduces boilerplate, keeps route files focused on page concerns, and lowers the risk of those routes drifting out of sync.

## Summary of changes

- added a shared `withConnection(...)` helper to manage MySQL connection lifecycle
- refactored internal route loaders to return plain objects instead of wrapping data in `NextResponse.json(...).json()`
- updated `getTunneller()` and `getTunnellers()` to follow the plain-data pattern consistently
- added a shared `getTunnellerBySlug(...)` helper for the profile and timeline routes
- removed duplicated numeric-slug redirect and fetch logic from the tunneller pages

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
