### PR TITLE
[NZT-113] Deduplicate JSON-LD metadata helpers

### DIFF
--- a/app/[locale]/books/kiwis-dig-tunnels-too/[id]/page.tsx
+++ b/app/[locale]/books/kiwis-dig-tunnels-too/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Chapter } from "@/components/Books/Chapter/Chapter";
 import { Locale } from "@/types/locale";
 import { bookTitle } from "@/utils/helpers/books/basePathUtil";
 import { readBookMarkdown } from "@/utils/helpers/books/markdownUtil";
+import { jsonLdAuthor, jsonLdPublisher } from "@/utils/helpers/jsonLd";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 export function generateStaticParams() {
@@ -60,15 +61,8 @@ export default async function Page(props: Props) {
       name: bookTitle(locale),
     },
     url: pageUrl(locale, `/books/kiwis-dig-tunnels-too/${id}/`),
-    author: {
-      "@type": "Person",
-      name: "Anthony Byledbal",
-    },
-    publisher: {
-      "@type": "Organization",
-      name: "New Zealand Tunnellers",
-      url: "https://www.nztunnellers.com",
-    },
+    author: jsonLdAuthor,
+    publisher: jsonLdPublisher,
   };
 
   return (

--- a/app/[locale]/books/kiwis-dig-tunnels-too/page.tsx
+++ b/app/[locale]/books/kiwis-dig-tunnels-too/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import ContentsContainer from "@/components/Books/Contents/ContentsContainer";
 import { Locale } from "@/types/locale";
 import { bookTitle } from "@/utils/helpers/books/basePathUtil";
+import { jsonLdAuthor, jsonLdPublisher } from "@/utils/helpers/jsonLd";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 export function generateStaticParams() {
@@ -37,15 +38,8 @@ export default async function Page({ params }: Props) {
     name: bookTitle(locale),
     inLanguage: locale,
     url: pageUrl(locale, "/books/kiwis-dig-tunnels-too/"),
-    author: {
-      "@type": "Person",
-      name: "Anthony Byledbal",
-    },
-    publisher: {
-      "@type": "Organization",
-      name: "New Zealand Tunnellers",
-      url: "https://www.nztunnellers.com",
-    },
+    author: jsonLdAuthor,
+    publisher: jsonLdPublisher,
   };
 
   return (

--- a/app/[locale]/history/[id]/page.tsx
+++ b/app/[locale]/history/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/utils/database/queries/historyChapterQuery";
 import { withConnection } from "@/utils/database/withConnection";
 import { getNextChapter } from "@/utils/helpers/article";
+import { jsonLdAuthor, jsonLdPublisher } from "@/utils/helpers/jsonLd";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 type Props = {
@@ -93,15 +94,8 @@ export default async function Page(props: Props) {
     headline: article.title.replace(/\\/g, " "),
     inLanguage: locale,
     url: pageUrl(locale, `/history/${id}/`),
-    author: {
-      "@type": "Person",
-      name: "Anthony Byledbal",
-    },
-    publisher: {
-      "@type": "Organization",
-      name: "New Zealand Tunnellers",
-      url: "https://www.nztunnellers.com",
-    },
+    author: jsonLdAuthor,
+    publisher: jsonLdPublisher,
   };
 
   return (

--- a/app/[locale]/tunnellers/[slug]/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Profile } from "@/components/Profile/Profile";
 import { Locale } from "@/types/locale";
 import { TunnellerProfile } from "@/types/tunneller";
 import { getTunnellerBySlug } from "@/utils/database/getTunnellerBySlug";
+import { buildTunnellerJsonLd } from "@/utils/helpers/jsonLd";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 type Props = {
@@ -46,35 +47,19 @@ export default async function Page(props: Props) {
   const awmm = tunneller.sources.awmmCenotaph;
   const image = tunneller.image?.url;
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    name: `${forename} ${surname}`,
-    givenName: forename,
+  const jsonLd = buildTunnellerJsonLd({
+    awmm,
+    birthDate,
+    birthPlace,
+    deathCountry,
+    deathDate,
+    deathTown,
     familyName: surname,
+    givenName: forename,
+    image,
     jobTitle: rank,
-    memberOf: {
-      "@type": "Organization",
-      name: "New Zealand Tunnelling Company",
-    },
     url: pageUrl(locale, `/tunnellers/${slug}/`),
-    ...(image && {
-      image: `https://www.nztunnellers.com/images/roll/tunnellers/${image}`,
-    }),
-    ...(birthDate && { birthDate }),
-    ...(birthPlace && {
-      birthPlace: { "@type": "Place", addressCountry: birthPlace },
-    }),
-    ...(deathDate && { deathDate }),
-    ...((deathTown || deathCountry) && {
-      deathPlace: {
-        "@type": "Place",
-        ...(deathTown && { name: deathTown }),
-        ...(deathCountry && { addressCountry: deathCountry }),
-      },
-    }),
-    ...(awmm && { sameAs: awmm }),
-  };
+  });
 
   return (
     <>

--- a/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
@@ -4,6 +4,7 @@ import { Timeline } from "@/components/Timeline/Timeline";
 import { Locale } from "@/types/locale";
 import { TunnellerProfile } from "@/types/tunneller";
 import { getTunnellerBySlug } from "@/utils/database/getTunnellerBySlug";
+import { buildTunnellerJsonLd } from "@/utils/helpers/jsonLd";
 import { buildPageMetadata, pageUrl } from "@/utils/helpers/metadata";
 
 type Props = {
@@ -59,35 +60,19 @@ export default async function Page(props: Props) {
   const awmm = tunneller.sources.awmmCenotaph;
   const image = tunneller.image?.url;
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    name: `${forename} ${surname}`,
-    givenName: forename,
+  const jsonLd = buildTunnellerJsonLd({
+    awmm,
+    birthDate,
+    birthPlace,
+    deathCountry,
+    deathDate,
+    deathTown,
     familyName: surname,
+    givenName: forename,
+    image,
     jobTitle: rank,
-    memberOf: {
-      "@type": "Organization",
-      name: "New Zealand Tunnelling Company",
-    },
     url: pageUrl(locale, `/tunnellers/${slug}/`),
-    ...(image && {
-      image: `https://www.nztunnellers.com/images/roll/tunnellers/${image}`,
-    }),
-    ...(birthDate && { birthDate }),
-    ...(birthPlace && {
-      birthPlace: { "@type": "Place", addressCountry: birthPlace },
-    }),
-    ...(deathDate && { deathDate }),
-    ...((deathTown || deathCountry) && {
-      deathPlace: {
-        "@type": "Place",
-        ...(deathTown && { name: deathTown }),
-        ...(deathCountry && { addressCountry: deathCountry }),
-      },
-    }),
-    ...(awmm && { sameAs: awmm }),
-  };
+  });
 
   return (
     <>

--- a/utils/helpers/jsonLd.ts
+++ b/utils/helpers/jsonLd.ts
@@ -12,15 +12,15 @@ export const jsonLdPublisher = {
 } as const;
 
 type TunnellerJsonLdInput = {
-  awmm?: string;
-  birthDate?: string;
-  birthPlace?: string;
-  deathCountry?: string;
-  deathDate?: string;
-  deathTown?: string;
+  awmm?: string | null;
+  birthDate?: string | null;
+  birthPlace?: string | null;
+  deathCountry?: string | null;
+  deathDate?: string | null;
+  deathTown?: string | null;
   familyName: string;
   givenName: string;
-  image?: string;
+  image?: string | null;
   jobTitle: string;
   url: string;
 };

--- a/utils/helpers/jsonLd.ts
+++ b/utils/helpers/jsonLd.ts
@@ -1,0 +1,68 @@
+import { BASE_URL } from "@/utils/helpers/metadata";
+
+export const jsonLdAuthor = {
+  "@type": "Person",
+  name: "Anthony Byledbal",
+} as const;
+
+export const jsonLdPublisher = {
+  "@type": "Organization",
+  name: "New Zealand Tunnellers",
+  url: BASE_URL,
+} as const;
+
+type TunnellerJsonLdInput = {
+  awmm?: string;
+  birthDate?: string;
+  birthPlace?: string;
+  deathCountry?: string;
+  deathDate?: string;
+  deathTown?: string;
+  familyName: string;
+  givenName: string;
+  image?: string;
+  jobTitle: string;
+  url: string;
+};
+
+export const buildTunnellerJsonLd = ({
+  awmm,
+  birthDate,
+  birthPlace,
+  deathCountry,
+  deathDate,
+  deathTown,
+  familyName,
+  givenName,
+  image,
+  jobTitle,
+  url,
+}: TunnellerJsonLdInput) => ({
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: `${givenName} ${familyName}`,
+  givenName,
+  familyName,
+  jobTitle,
+  memberOf: {
+    "@type": "Organization",
+    name: "New Zealand Tunnelling Company",
+  },
+  url,
+  ...(image && {
+    image: `${BASE_URL}/images/roll/tunnellers/${image}`,
+  }),
+  ...(birthDate && { birthDate }),
+  ...(birthPlace && {
+    birthPlace: { "@type": "Place", addressCountry: birthPlace },
+  }),
+  ...(deathDate && { deathDate }),
+  ...((deathTown || deathCountry) && {
+    deathPlace: {
+      "@type": "Place",
+      ...(deathTown && { name: deathTown }),
+      ...(deathCountry && { addressCountry: deathCountry }),
+    },
+  }),
+  ...(awmm && { sameAs: awmm }),
+});


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
This PR simplifies the structured data definitions used across the app by extracting the repeated JSON-LD fragments into shared helpers.

Several pages repeated the same JSON-LD literals:
- author information
- publisher information
- tunneller `Person` schema fields

This change reduces duplication while keeping each page’s schema type explicit (`Book`, `Article`, `Person`).

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- added a shared `jsonLd.ts` helper module
- extracted reusable `author` and `publisher` JSON-LD fragments
- extracted a shared `buildTunnellerJsonLd(...)` helper for tunneller profile and timeline pages
- updated the book, history, and tunneller routes to use the shared helpers

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
