### PR TITLE
[NZT-114] Refactor shared button styles for map controls

### DIFF
--- a/app/variables.module.scss
+++ b/app/variables.module.scss
@@ -123,6 +123,13 @@ $border-radius: 8px;
   }
 }
 
+@mixin text-link-button {
+  all: unset;
+  cursor: pointer;
+
+  @include text-link;
+}
+
 .link {
   font-size: 1rem;
   font-weight: 500;
@@ -161,6 +168,23 @@ $border-radius: 8px;
 
   &:hover {
     border: 1px solid $secondary-color;
+    background-color: $primary-dark-color;
+  }
+}
+
+@mixin outlined-control {
+  background-color: $primary-medium-color;
+  border: 1px solid $primary-light-color;
+  border-radius: $border-radius;
+  color: $secondary-color;
+  cursor: pointer;
+  transition:
+    border-color 0.9s ease-in-out,
+    background-color 0.9s ease-in-out,
+    color 0.9s ease-in-out;
+
+  &:hover:not(:disabled) {
+    border-color: $secondary-color;
     background-color: $primary-dark-color;
   }
 }

--- a/components/Dialog/Dialog.module.scss
+++ b/components/Dialog/Dialog.module.scss
@@ -70,10 +70,7 @@
   border-bottom: 1px solid variables.$primary-medium-color;
 
   button {
-    all: unset;
-    cursor: pointer;
-
-    @include variables.text-link;
+    @include variables.text-link-button;
   }
 }
 
@@ -113,10 +110,7 @@
 }
 
 .dialog-cancel-button {
-  all: unset;
-  cursor: pointer;
-
-  @include variables.text-link;
+  @include variables.text-link-button;
 
   &:disabled {
     color: variables.$primary-light-color;

--- a/components/Roll/Roll.module.scss
+++ b/components/Roll/Roll.module.scss
@@ -58,11 +58,9 @@
     }
 
     @include variables.desktop {
-      all: unset;
-      cursor: pointer;
       display: inline-block;
 
-      @include variables.text-link;
+      @include variables.text-link-button;
 
       &:disabled {
         color: variables.$primary-light-color;

--- a/components/WorksMap/MapControls/MapControls.module.scss
+++ b/components/WorksMap/MapControls/MapControls.module.scss
@@ -3,20 +3,9 @@
 .period-toggle {
   grid-column: 1;
   grid-row: 1;
-  background-color: variables.$primary-medium-color;
-  border: 1px solid variables.$primary-light-color;
-  border-radius: variables.$border-radius;
-  color: variables.$secondary-color;
   font-size: 1rem;
-  cursor: pointer;
-  transition:
-    border-color 0.9s ease-in-out,
-    background-color 0.9s ease-in-out;
 
-  &:hover {
-    border-color: variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
-  }
+  @include variables.outlined-control;
 
   &--active {
     background-color: variables.$secondary-color;
@@ -60,25 +49,13 @@
   align-items: center;
   justify-content: center;
   align-self: stretch;
-  background-color: variables.$primary-medium-color;
-  border: 1px solid variables.$primary-light-color;
-  border-radius: variables.$border-radius;
-  color: variables.$secondary-color;
   font-family: variables.$main-font;
   font-size: 1.9rem;
   font-weight: 200;
-  cursor: pointer;
-  transition:
-    border-color 0.9s ease-in-out,
-    background-color 0.9s ease-in-out;
 
-  &:hover:not(:disabled) {
-    background-color: variables.$primary-dark-color;
-    border: 1px solid variables.$secondary-color;
-  }
+  @include variables.outlined-control;
 
   &:disabled {
-    border: 1px solid variables.$primary-light-color;
     color: variables.$primary-light-color;
     cursor: not-allowed;
   }
@@ -95,20 +72,11 @@
   flex-direction: column;
   flex-shrink: 0;
   gap: 2px;
-  background-color: variables.$primary-medium-color;
-  border: 1px solid variables.$primary-light-color;
-  border-radius: variables.$border-radius;
   padding: variables.$xxs-margin;
-  cursor: pointer;
   text-align: left;
-  color: variables.$secondary-color;
   font: inherit;
-  transition: all 0.9s ease-in-out;
 
-  &:hover {
-    border-color: variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
-  }
+  @include variables.outlined-control;
 
   &--active {
     background-color: variables.$secondary-color;
@@ -250,11 +218,10 @@
 .zoom-btn {
   width: 45px;
   height: 45px;
-  background-color: variables.$primary-medium-color;
-  color: variables.$secondary-color;
-  border: 1px solid variables.$primary-light-color;
-  border-radius: variables.$border-radius;
   font-size: 1.5rem;
+  line-height: 1;
+
+  @include variables.outlined-control;
 
   @include variables.tablet {
     font-size: 1.6rem;
@@ -264,19 +231,7 @@
     font-size: 1.7rem;
   }
 
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    border 0.9s ease-in-out,
-    background-color 0.9s ease-in-out;
-
-  &:hover:not(:disabled) {
-    background-color: variables.$primary-dark-color;
-    border-color: variables.$secondary-color;
-  }
-
   &:disabled {
-    border-color: variables.$primary-light-color;
     color: variables.$primary-light-color;
     cursor: not-allowed;
   }

--- a/components/WorksMap/TypeFilter/TypeFilter.module.scss
+++ b/components/WorksMap/TypeFilter/TypeFilter.module.scss
@@ -24,25 +24,13 @@
   align-items: center;
   justify-content: center;
   align-self: stretch;
-  background-color: variables.$primary-medium-color;
-  border: 1px solid variables.$primary-light-color;
-  border-radius: variables.$border-radius;
-  color: variables.$secondary-color;
   font-family: variables.$main-font;
   font-size: 1.9rem;
   font-weight: 200;
-  cursor: pointer;
-  transition:
-    border-color 0.9s ease-in-out,
-    background-color 0.9s ease-in-out;
 
-  &:hover:not(:disabled) {
-    background-color: variables.$primary-dark-color;
-    border: 1px solid variables.$secondary-color;
-  }
+  @include variables.outlined-control;
 
   &:disabled {
-    border: 1px solid variables.$primary-light-color;
     color: variables.$primary-light-color;
     cursor: not-allowed;
   }
@@ -60,25 +48,12 @@
   gap: variables.$xxxs-margin;
   flex-shrink: 0;
   padding: 13px variables.$xxs-margin;
-
-  background-color: variables.$primary-medium-color;
-  border: 1px solid variables.$primary-light-color;
-  border-radius: variables.$border-radius;
-  color: variables.$secondary-color;
   font: inherit;
   font-size: 0.9rem;
   font-weight: 500;
   white-space: nowrap;
-  cursor: pointer;
-  transition:
-    border-color 0.9s ease-in-out,
-    background-color 0.9s ease-in-out,
-    color 0.9s ease-in-out;
 
-  &:hover {
-    border-color: variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
-  }
+  @include variables.outlined-control;
 
   &--active {
     background-color: variables.$secondary-color;


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
This PR simplifies the shared button styling used by the map controls by extracting common SCSS mixins and applying them to the existing map UI components.

Several components repeated the same styling patterns:
- `all: unset` + pointer + text-link styling
- dark background + light border + hover/transition control shells

This change reduces CSS duplication and keeps the component-specific active and disabled states local, while centralising the shared visual shell.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- added a shared `text-link-button` mixin for reset-style text action buttons
- added a shared `outlined-control` mixin for compact dark outlined controls
- updated the dialog and roll reset button styles to use `text-link-button`
- updated the map controls and type filter styles to use `outlined-control`

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
