### PR TITLE
[NZT-115] Add roll sort toggle and sync order with URL

### DIFF
--- a/__tests__/unit/components/Roll/Roll.test.tsx
+++ b/__tests__/unit/components/Roll/Roll.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, screen, render, within } from "@testing-library/react";
+import {
+  fireEvent,
+  screen,
+  render,
+  within,
+  waitFor,
+} from "@testing-library/react";
 import { mockTunnellers } from "__tests__/unit/utils/mocks/mockTunnellers";
 
 import { Roll } from "@/components/Roll/Roll";
@@ -368,6 +374,42 @@ describe("Roll", () => {
     expect(screen.getByText("Birth")).toBeInTheDocument();
     expect(screen.getByText("Death")).toBeInTheDocument();
     expect(screen.getByText("Ranks")).toBeInTheDocument();
+  });
+
+  test("reverses the roll order when sort button is clicked", async () => {
+    await renderRoll();
+
+    const before = screen
+      .getAllByRole("heading", { level: 2 })
+      .map((heading) => {
+        return heading.textContent;
+      });
+    expect(before).toEqual(["B", "D", "M", "T"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Z to A" }));
+
+    const after = screen
+      .getAllByRole("heading", { level: 2 })
+      .map((heading) => {
+        return heading.textContent;
+      });
+    expect(after).toEqual(["T", "M", "D", "B"]);
+    expect(screen.getByRole("button", { name: "A to Z" })).toBeInTheDocument();
+  });
+
+  test("resets to page 1 when sort order changes", async () => {
+    mockSearchParams = new URLSearchParams("page=2");
+
+    await renderRoll();
+
+    const sortButtons = screen.getAllByRole("button", { name: "Z to A" });
+    fireEvent.click(sortButtons[0]);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("?sort=desc", {
+        scroll: false,
+      });
+    });
   });
 
   test("should filter Tunnelling Corps shows only tunnellers without attached corps", async () => {

--- a/__tests__/unit/components/Roll/__snapshots__/Roll.test.tsx.snap
+++ b/__tests__/unit/components/Roll/__snapshots__/Roll.test.tsx.snap
@@ -26,26 +26,62 @@ exports[`Roll matches the snapshot 1`] = `
       </div>
     </div>
     <div
+      class="header-summary"
+    >
+      <div
+        class="header-actions"
+      >
+        <button
+          class="reset-button"
+          disabled=""
+        >
+          Reset filters
+        </button>
+      </div>
+      <div
+        class="header-meta"
+      >
+        <p
+          class="results"
+        >
+          4 results
+        </p>
+        <button
+          aria-label="Z to A"
+          class="sort-button"
+        >
+          <span
+            class="sort-button-label"
+          >
+            <span
+              class="sort-button-letters"
+            >
+              <span
+                class="sort-button-top"
+              >
+                Z
+              </span>
+              <span
+                class="sort-button-bottom"
+              >
+                A
+              </span>
+            </span>
+            <span
+              class="sort-button-arrow"
+            >
+              ↓
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
       class="roll-container"
     >
       <div
         class="controls"
       >
-        <div
-          class="results-container"
-        >
-          <button
-            class="reset-button"
-            disabled=""
-          >
-            Reset filters
-          </button>
-          <p
-            class="results"
-          >
-            4 results
-          </p>
-        </div>
         <button
           class="filter-button "
         >

--- a/__tests__/unit/utils/helpers/rollParams.test.ts
+++ b/__tests__/unit/utils/helpers/rollParams.test.ts
@@ -45,58 +45,64 @@ const make = (qs: string) =>
 
 describe("filtersToSearchParams", () => {
   test("returns empty string for default filters on page 1", () => {
-    expect(filtersToSearchParams(defaultFilters, 1, lookups)).toBe("");
+    expect(filtersToSearchParams(defaultFilters, 1, "asc", lookups)).toBe("");
   });
 
   test("includes page when greater than 1", () => {
-    expect(filtersToSearchParams(defaultFilters, 3, lookups)).toContain(
+    expect(filtersToSearchParams(defaultFilters, 3, "asc", lookups)).toContain(
       "page=3",
+    );
+  });
+
+  test("includes sort when descending", () => {
+    expect(filtersToSearchParams(defaultFilters, 1, "desc", lookups)).toContain(
+      "sort=desc",
     );
   });
 
   test("serialises detachment IDs as slugs", () => {
     const filters = { ...defaultFilters, detachment: [1, 2] };
-    expect(filtersToSearchParams(filters, 1, lookups)).toContain(
+    expect(filtersToSearchParams(filters, 1, "asc", lookups)).toContain(
       "detachment=main-body,2nd-reinforcements",
     );
   });
 
   test("serialises null ID as slug for Tunnelling Corps", () => {
     const filters = { ...defaultFilters, corps: [null] };
-    expect(filtersToSearchParams(filters, 1, lookups)).toContain(
+    expect(filtersToSearchParams(filters, 1, "asc", lookups)).toContain(
       "corps=tunnelling-corps",
     );
   });
 
   test("serialises mixed null and numeric corps IDs as slugs", () => {
     const filters = { ...defaultFilters, corps: [null, 2] };
-    expect(filtersToSearchParams(filters, 1, lookups)).toContain(
+    expect(filtersToSearchParams(filters, 1, "asc", lookups)).toContain(
       "corps=tunnelling-corps,army-pay-corps",
     );
   });
 
   test("serialises birth year range", () => {
     const filters = { ...defaultFilters, birthYear: ["1886", "1897"] };
-    const qs = filtersToSearchParams(filters, 1, lookups);
+    const qs = filtersToSearchParams(filters, 1, "asc", lookups);
     expect(qs).toContain("birth-min=1886");
     expect(qs).toContain("birth-max=1897");
   });
 
   test("does not include birth range when full default range", () => {
-    const qs = filtersToSearchParams(defaultFilters, 1, lookups);
+    const qs = filtersToSearchParams(defaultFilters, 1, "asc", lookups);
     expect(qs).not.toContain("birth-min");
   });
 
   test("sets unknown-birth=0 when unknowns excluded", () => {
     const filters = { ...defaultFilters, unknownBirthYear: "" };
-    expect(filtersToSearchParams(filters, 1, lookups)).toContain(
+    expect(filtersToSearchParams(filters, 1, "asc", lookups)).toContain(
       "unknown-birth=0",
     );
   });
 
   test("does not encode commas as %2C", () => {
     const filters = { ...defaultFilters, detachment: [1, 2] };
-    const qs = filtersToSearchParams(filters, 1, lookups);
+    const qs = filtersToSearchParams(filters, 1, "asc", lookups);
     expect(qs).not.toContain("%2C");
   });
 
@@ -105,7 +111,7 @@ describe("filtersToSearchParams", () => {
       ...defaultFilters,
       ranks: { ...defaultFilters.ranks, Officers: [1, 2] },
     };
-    expect(filtersToSearchParams(filters, 1, lookups)).toContain(
+    expect(filtersToSearchParams(filters, 1, "asc", lookups)).toContain(
       "officer=major,captain",
     );
   });
@@ -113,11 +119,20 @@ describe("filtersToSearchParams", () => {
 
 describe("searchParamsToFilters", () => {
   test("returns defaults and page 1 for empty params", () => {
-    const { filters, page } = searchParamsToFilters(make(""), lookups);
+    const { filters, page, sortOrder } = searchParamsToFilters(
+      make(""),
+      lookups,
+    );
     expect(page).toBe(1);
+    expect(sortOrder).toBe("asc");
     expect(filters.detachment).toEqual([]);
     expect(filters.birthYear).toEqual(lookups.birthYears);
     expect(filters.unknownBirthYear).toBe("unknown");
+  });
+
+  test("parses descending sort", () => {
+    const { sortOrder } = searchParamsToFilters(make("sort=desc"), lookups);
+    expect(sortOrder).toBe("desc");
   });
 
   test("parses page number", () => {
@@ -173,12 +188,13 @@ describe("searchParamsToFilters", () => {
       deathYear: ["1935", "1952"],
       unknownDeathYear: "unknown",
     };
-    const qs = filtersToSearchParams(original, 2, lookups);
-    const { filters, page } = searchParamsToFilters(
+    const qs = filtersToSearchParams(original, 2, "desc", lookups);
+    const { filters, page, sortOrder } = searchParamsToFilters(
       make(qs) as unknown as Parameters<typeof searchParamsToFilters>[0],
       lookups,
     );
     expect(page).toBe(2);
+    expect(sortOrder).toBe("desc");
     expect(filters.detachment).toEqual([1, 2]);
     expect(filters.corps).toEqual([null, 2]);
     expect(filters.ranks["Officers"]).toEqual([1]);

--- a/components/Roll/Roll.module.scss
+++ b/components/Roll/Roll.module.scss
@@ -8,13 +8,133 @@
   }
 }
 
+.header-summary {
+  display: none;
+
+  @include variables.desktop {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: variables.$m-margin;
+    margin-top: variables.$xxl-margin;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: variables.$inner-width;
+  }
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: variables.$m-margin;
+}
+
+.header-meta {
+  display: flex;
+  align-items: center;
+  gap: variables.$xxs-margin;
+
+  @include variables.desktop {
+    gap: variables.$m-margin;
+  }
+}
+
+.mobile-actions {
+  display: flex;
+  align-items: center;
+  gap: variables.$xxxs-margin;
+
+  @include variables.desktop {
+    display: none;
+  }
+}
+
+.results {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.reset-button {
+  display: none;
+
+  @include variables.tablet {
+    display: none;
+  }
+
+  @include variables.desktop {
+    all: unset;
+    cursor: pointer;
+    display: inline-block;
+
+    @include variables.text-link;
+
+    &:disabled {
+      color: variables.$primary-light-color;
+      border-bottom-color: variables.$primary-light-color;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 7px 6px 10px;
+  height: 40.5px;
+  width: 40.5px;
+  font: inherit;
+  text-align: center;
+  color: variables.$secondary-color;
+  border-radius: variables.$border-radius;
+  border: 1px solid variables.$primary-light-color;
+  background-color: variables.$primary-medium-color;
+  transition:
+    border 0.9s ease-in-out,
+    background-color 0.9s ease-in-out;
+  cursor: pointer;
+
+  &:hover {
+    border: 1px solid variables.$secondary-color;
+    background-color: variables.$primary-dark-color;
+  }
+}
+
+.sort-button-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sort-button-letters {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  line-height: 0.85;
+}
+
+.sort-button-arrow {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.sort-button-top,
+.sort-button-bottom {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.sort-button-bottom {
+  font-size: 0.65rem;
+}
+
 .roll-container {
   display: block;
 
   @include variables.desktop {
     display: flex;
     margin: 0 auto;
-    margin-top: variables.$xxl-margin;
     max-width: variables.$inner-width;
     gap: variables.$base-margin;
   }
@@ -39,37 +159,10 @@
   .results-container {
     display: flex;
     height: variables.$base-margin;
-    width: 85%;
+    width: 100%;
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-  }
-
-  .results {
-    font-size: 1.1rem;
-    font-weight: 500;
-  }
-
-  .reset-button {
-    display: none;
-
-    @include variables.tablet {
-      display: none;
-    }
-
-    @include variables.desktop {
-      all: unset;
-      cursor: pointer;
-      display: inline-block;
-
-      @include variables.text-link;
-
-      &:disabled {
-        color: variables.$primary-light-color;
-        border-bottom-color: variables.$primary-light-color;
-        cursor: not-allowed;
-      }
-    }
   }
 
   .filter-button {
@@ -126,7 +219,7 @@
 
     @include variables.desktop {
       display: block;
-      width: 85%;
+      width: 100%;
     }
   }
 }

--- a/components/Roll/Roll.tsx
+++ b/components/Roll/Roll.tsx
@@ -265,12 +265,12 @@ export function Roll({ tunnellers }: Props) {
     () => filteredGroups.reduce((acc, [, list]) => acc + list.length, 0),
     [filteredGroups],
   );
-  const sortedFilteredGroups = useMemo(() => {
+  const sortedFilteredGroups = useMemo<[string, Tunneller[]][]>(() => {
     const direction = sortOrder === "asc" ? 1 : -1;
 
     return [...filteredGroups]
       .sort(([groupA], [groupB]) => groupA.localeCompare(groupB) * direction)
-      .map(([group, list]) => [
+      .map<[string, Tunneller[]]>(([group, list]) => [
         group,
         [...list].sort((a, b) => {
           const surnameCompare =

--- a/components/Roll/Roll.tsx
+++ b/components/Roll/Roll.tsx
@@ -13,6 +13,7 @@ import { Tunneller } from "@/types/tunnellers";
 import {
   type FilterLookups,
   type Filters,
+  type RollSortOrder,
   filtersToSearchParams,
   searchParamsToFilters,
 } from "@/utils/helpers/rollParams";
@@ -135,6 +136,9 @@ export function Roll({ tunnellers }: Props) {
 
   const [filters, setFilters] = useState<Filters>(parsedUrlState.filters);
   const [currentPage, setCurrentPage] = useState<number>(parsedUrlState.page);
+  const [sortOrder, setSortOrder] = useState<RollSortOrder>(
+    parsedUrlState.sortOrder,
+  );
   const searchParamsString = searchParams.toString();
 
   /** ---- Re-sync local state when URL changes after mount ---- */
@@ -152,12 +156,15 @@ export function Roll({ tunnellers }: Props) {
       if (currentPage !== parsedUrlState.page) {
         setCurrentPage(parsedUrlState.page);
       }
+      if (sortOrder !== parsedUrlState.sortOrder) {
+        setSortOrder(parsedUrlState.sortOrder);
+      }
     });
 
     return () => {
       cancelled = true;
     };
-  }, [searchParamsString, parsedUrlState, filters, currentPage]);
+  }, [searchParamsString, parsedUrlState, filters, currentPage, sortOrder]);
 
   /** ---- Sync URL params when state changes ---- */
   useEffect(() => {
@@ -165,11 +172,16 @@ export function Roll({ tunnellers }: Props) {
       isFirstRenderRef.current = false;
       return;
     }
-    const qs = filtersToSearchParams(filters, currentPage, filterLookups);
+    const qs = filtersToSearchParams(
+      filters,
+      currentPage,
+      sortOrder,
+      filterLookups,
+    );
     const currentQs = window.location.search.replace(/^\?/, "");
     if (qs === currentQs) return;
     router.replace(`?${qs}`, { scroll: false });
-  }, [filters, currentPage, router, filterLookups]);
+  }, [filters, currentPage, router, filterLookups, sortOrder]);
 
   /** ---- Restore scroll position on mount ---- */
   useEffect(() => {
@@ -253,6 +265,21 @@ export function Roll({ tunnellers }: Props) {
     () => filteredGroups.reduce((acc, [, list]) => acc + list.length, 0),
     [filteredGroups],
   );
+  const sortedFilteredGroups = useMemo(() => {
+    const direction = sortOrder === "asc" ? 1 : -1;
+
+    return [...filteredGroups]
+      .sort(([groupA], [groupB]) => groupA.localeCompare(groupB) * direction)
+      .map(([group, list]) => [
+        group,
+        [...list].sort((a, b) => {
+          const surnameCompare =
+            a.name.surname.localeCompare(b.name.surname) * direction;
+          if (surnameCompare !== 0) return surnameCompare;
+          return a.name.forename.localeCompare(b.name.forename) * direction;
+        }),
+      ]);
+  }, [filteredGroups, sortOrder]);
   const totalTunnellers = useMemo(
     () => tunnellersList.reduce((acc, [, list]) => acc + list.length, 0),
     [tunnellersList],
@@ -376,6 +403,10 @@ export function Roll({ tunnellers }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const onClose = useCallback(() => setIsOpen(false), []);
   const handleFilterButton = useCallback(() => setIsOpen(true), []);
+  const handleSortToggle = useCallback(() => {
+    setCurrentPage(1);
+    setSortOrder((current) => (current === "asc" ? "desc" : "asc"));
+  }, []);
 
   const rollFiltersProps = {
     className: STYLES["filters-container"],
@@ -399,6 +430,13 @@ export function Roll({ tunnellers }: Props) {
   };
 
   const isDesktop = () => (width ? width > 896 : false);
+  const desktopView = isDesktop();
+  const resultsText =
+    totalFilteredTunnellers > 1
+      ? t("resultsPlural", { count: totalFilteredTunnellers })
+      : t("results", { count: totalFilteredTunnellers });
+  const isAscending = sortOrder === "asc";
+  const sortButtonText = isAscending ? t("sortDescending") : t("sortAscending");
 
   return (
     <>
@@ -419,10 +457,9 @@ export function Roll({ tunnellers }: Props) {
         <div className={STYLES.header}>
           <Title title={t("title")} />
         </div>
-
-        <div className={STYLES["roll-container"]}>
-          <div className={STYLES.controls}>
-            <div className={STYLES["results-container"]}>
+        {desktopView ? (
+          <div className={STYLES["header-summary"]}>
+            <div className={STYLES["header-actions"]}>
               <button
                 className={STYLES["reset-button"]}
                 onClick={handleResetFilters}
@@ -430,29 +467,89 @@ export function Roll({ tunnellers }: Props) {
               >
                 {t("resetFilters")}
               </button>
-              <p className={STYLES.results}>
-                {totalFilteredTunnellers > 1
-                  ? t("resultsPlural", { count: totalFilteredTunnellers })
-                  : t("results", { count: totalFilteredTunnellers })}
-              </p>
             </div>
-            <button
-              className={`${STYLES["filter-button"]} ${activeFilterCount > 0 ? STYLES["filter-button--active"] : ""}`}
-              onClick={handleFilterButton}
-            >
-              {t("filters")}
-              {activeFilterCount > 0 && (
-                <span className={STYLES["filter-button-badge"]}>
-                  {activeFilterCount}
+            <div className={STYLES["header-meta"]}>
+              <p className={STYLES.results}>{resultsText}</p>
+              <button
+                className={STYLES["sort-button"]}
+                onClick={handleSortToggle}
+                aria-label={sortButtonText}
+              >
+                <span className={STYLES["sort-button-label"]}>
+                  <span className={STYLES["sort-button-letters"]}>
+                    <span className={STYLES["sort-button-top"]}>
+                      {isAscending ? "Z" : "A"}
+                    </span>
+                    <span className={STYLES["sort-button-bottom"]}>
+                      {isAscending ? "A" : "Z"}
+                    </span>
+                  </span>
+                  <span className={STYLES["sort-button-arrow"]}>
+                    {isAscending ? "↓" : "↑"}
+                  </span>
                 </span>
-              )}
-            </button>
-            {isDesktop() ? <RollFilter {...rollFiltersProps} /> : null}
+              </button>
+            </div>
+          </div>
+        ) : null}
+        <div className={STYLES["roll-container"]}>
+          <div className={STYLES.controls}>
+            {!desktopView ? (
+              <div className={STYLES["results-container"]}>
+                <p className={STYLES.results}>{resultsText}</p>
+                <div className={STYLES["mobile-actions"]}>
+                  <button
+                    className={STYLES["sort-button"]}
+                    onClick={handleSortToggle}
+                    aria-label={sortButtonText}
+                  >
+                    <span className={STYLES["sort-button-label"]}>
+                      <span className={STYLES["sort-button-letters"]}>
+                        <span className={STYLES["sort-button-top"]}>
+                          {isAscending ? "Z" : "A"}
+                        </span>
+                        <span className={STYLES["sort-button-bottom"]}>
+                          {isAscending ? "A" : "Z"}
+                        </span>
+                      </span>
+                      <span className={STYLES["sort-button-arrow"]}>
+                        {isAscending ? "↓" : "↑"}
+                      </span>
+                    </span>
+                  </button>
+                  <button
+                    className={`${STYLES["filter-button"]} ${activeFilterCount > 0 ? STYLES["filter-button--active"] : ""}`}
+                    onClick={handleFilterButton}
+                  >
+                    {t("filters")}
+                    {activeFilterCount > 0 && (
+                      <span className={STYLES["filter-button-badge"]}>
+                        {activeFilterCount}
+                      </span>
+                    )}
+                  </button>
+                </div>
+              </div>
+            ) : null}
+            {desktopView ? (
+              <button
+                className={`${STYLES["filter-button"]} ${activeFilterCount > 0 ? STYLES["filter-button--active"] : ""}`}
+                onClick={handleFilterButton}
+              >
+                {t("filters")}
+                {activeFilterCount > 0 && (
+                  <span className={STYLES["filter-button-badge"]}>
+                    {activeFilterCount}
+                  </span>
+                )}
+              </button>
+            ) : null}
+            {desktopView ? <RollFilter {...rollFiltersProps} /> : null}
           </div>
 
           {filteredGroups.length > 0 ? (
             <RollAlphabet
-              tunnellers={filteredGroups}
+              tunnellers={sortedFilteredGroups}
               currentPage={currentPage}
               onPageChange={setCurrentPage}
             />

--- a/messages/en.json
+++ b/messages/en.json
@@ -58,6 +58,8 @@
     "title": "The New Zealand\\Tunnellers",
     "filters": "Filters",
     "resetFilters": "Reset filters",
+    "sortAscending": "A to Z",
+    "sortDescending": "Z to A",
     "results": "{count} result",
     "resultsPlural": "{count} results",
     "detachments": "Detachments",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -58,6 +58,8 @@
     "title": "Les Tunneliers\\néo-zélandais",
     "filters": "Filtres",
     "resetFilters": "Supprimer les filtres",
+    "sortAscending": "A à Z",
+    "sortDescending": "Z à A",
     "results": "{count} résultat",
     "resultsPlural": "{count} résultats",
     "detachments": "Détachements",

--- a/utils/helpers/rollParams.ts
+++ b/utils/helpers/rollParams.ts
@@ -20,6 +20,8 @@ export type FilterLookups = {
   deathYears: string[];
 };
 
+export type RollSortOrder = "asc" | "desc";
+
 function slugify(label: string): string {
   return label
     .toLowerCase()
@@ -54,9 +56,10 @@ function slugsToIds(
 export function searchParamsToFilters(
   params: ReadonlyURLSearchParams,
   lookups: FilterLookups,
-): { filters: Filters; page: number } {
+): { filters: Filters; page: number; sortOrder: RollSortOrder } {
   const pageRaw = Number(params.get("page"));
   const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : 1;
+  const sortOrder = params.get("sort") === "desc" ? "desc" : "asc";
 
   const birthMin = params.get("birth-min");
   const birthMax = params.get("birth-max");
@@ -74,6 +77,7 @@ export function searchParamsToFilters(
 
   return {
     page,
+    sortOrder,
     filters: {
       detachment: slugsToIds(params.get("detachment"), lookups.detachments),
       corps: slugsToIds(params.get("corps"), lookups.corps),
@@ -99,11 +103,13 @@ export function searchParamsToFilters(
 export function filtersToSearchParams(
   filters: Filters,
   page: number,
+  sortOrder: RollSortOrder,
   lookups: FilterLookups,
 ): string {
   const params = new URLSearchParams();
 
   if (page > 1) params.set("page", String(page));
+  if (sortOrder === "desc") params.set("sort", "desc");
 
   if (filters.detachment.length > 0) {
     const slugs = idsToSlugs(filters.detachment, lookups.detachments);


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
This PR adds a sort toggle to the roll page, makes the list order shareable through the URL, and updates the roll controls layout on desktop and mobile.

The roll page needed a quick way to reverse the list order without losing the current filter state, and that order should be preserved when the page is refreshed or shared.

This change keeps sorting consistent with the existing URL-driven filter state and avoids confusing pagination by resetting back to the first page when the order changes.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- added a roll sort toggle for `A to Z` / `Z to A`
- added the same sort control to both desktop and mobile layouts
- stored descending order in the URL with `sort=desc`
- restored sort order from query params on load and navigation
- reset pagination back to page 1 when sort order changes
- moved the desktop summary actions into a dedicated row below the title
- refined the roll control spacing and button styling for the new layout

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
