### PR TITLE
[NZT-116] Remove personal author name from tunneller citations

### DIFF
--- a/__tests__/unit/components/HowToCite/HowToCite.text.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.text.tsx
@@ -175,6 +175,7 @@ describe("HowToCite", () => {
     );
 
     expect(screen.getByText(/John Smith/)).toBeInTheDocument();
+    expect(screen.queryByText(/Anthony Byledbal/)).not.toBeInTheDocument();
   });
 
   test("renders non-chapter citation for a prologue path", () => {
@@ -213,6 +214,7 @@ describe("HowToCite", () => {
     expect(
       screen.getByText(/World War I Timeline of John Smith/),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/Anthony Byledbal/)).not.toBeInTheDocument();
   });
 
   test("renders French timeline citation with French prefix", () => {

--- a/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
+++ b/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
@@ -349,7 +349,7 @@ exports[`Profile matches the snapshot 1`] = `
           </button>
         </h3>
         <p>
-          Anthony Byledbal, “John Smith (1886-1966)”, New Zealand Tunnellers Website, 2023 (2009), Accessed: 4 May 2023. 
+          “John Smith (1886-1966)”, New Zealand Tunnellers Website, 2023 (2009), Accessed: 4 May 2023. 
           <span>
             URL: www.
             <wbr />

--- a/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
@@ -454,7 +454,7 @@ exports[`Timeline matches the snapshot 1`] = `
         </button>
       </h3>
       <p>
-        Anthony Byledbal, “World War I Timeline of John Smith”, New Zealand Tunnellers Website, 2023 (2009), Accessed: 4 May 2023. 
+        “World War I Timeline of John Smith”, New Zealand Tunnellers Website, 2023 (2009), Accessed: 4 May 2023. 
         <span>
           URL: www.
           <wbr />

--- a/components/HowToCite/HowToCite.tsx
+++ b/components/HowToCite/HowToCite.tsx
@@ -238,6 +238,7 @@ export function HowToCite({
       }).format(now),
     [locale, now, userTimeZone],
   );
+  const citationAuthorPrefix = summary ? "" : "Anthony Byledbal, ";
 
   const handleCopy = () => {
     if (citationRef.current) {
@@ -284,7 +285,7 @@ export function HowToCite({
         </button>
       </h3>
       <p ref={citationRef}>
-        Anthony Byledbal,{" "}
+        {citationAuthorPrefix}
         <HowToCiteTitle
           tunneller={summary}
           title={title}


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
This PR updates the `HowToCite` component so tunneller profile and timeline pages no longer prefix citations with the author.

Profile and timeline pages behave more like reference or database pages than authored articles. Removing the personal author prefix makes those citations better match the nature of the content, while preserving authorship on editorial pages.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- updated `HowToCite` to omit the personal author prefix when rendering citations for tunneller profile and timeline pages
- kept the existing author prefix for authored content such as articles and book chapters
- added unit assertions to confirm the name is not shown for tunneller citations

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
