### PR TITLE
[NZT-118] Add hover for pointing device only

### DIFF
--- a/app/variables.module.scss
+++ b/app/variables.module.scss
@@ -44,6 +44,12 @@ $border-radius: 8px;
   }
 }
 
+@mixin hover-supported {
+  @media (hover: hover) and (pointer: fine) {
+    @content;
+  }
+}
+
 @mixin component-margin {
   margin-left: $s-margin;
   margin-right: $s-margin;
@@ -116,10 +122,12 @@ $border-radius: 8px;
     color 0.9s ease-in-out,
     border-bottom 0.9s ease-in-out;
 
-  &:hover {
-    padding-bottom: 4px;
-    border-bottom: 1px solid $secondary-color;
-    color: $secondary-color;
+  @include hover-supported {
+    &:hover {
+      padding-bottom: 4px;
+      border-bottom: 1px solid $secondary-color;
+      color: $secondary-color;
+    }
   }
 }
 
@@ -159,9 +167,11 @@ $border-radius: 8px;
     font-size: 1.35rem;
   }
 
-  &:hover {
-    border: 1px solid $secondary-color;
-    background-color: $primary-dark-color;
+  @include hover-supported {
+    &:hover {
+      border: 1px solid $secondary-color;
+      background-color: $primary-dark-color;
+    }
   }
 }
 

--- a/components/AboutUs/AboutUs.module.scss
+++ b/components/AboutUs/AboutUs.module.scss
@@ -106,9 +106,11 @@
     transition: all 0.9s ease-in-out;
     cursor: pointer;
 
-    &:hover {
-      border: 1px solid variables.$secondary-color;
-      background-color: variables.$primary-dark-color;
+    @include variables.hover-supported {
+      &:hover {
+        border: 1px solid variables.$secondary-color;
+        background-color: variables.$primary-dark-color;
+      }
     }
 
     @include variables.desktop {
@@ -131,9 +133,11 @@
     transition: all 0.9s ease-in-out;
     cursor: pointer;
 
-    &:hover {
-      border: 1px solid variables.$secondary-color;
-      background-color: variables.$primary-dark-color;
+    @include variables.hover-supported {
+      &:hover {
+        border: 1px solid variables.$secondary-color;
+        background-color: variables.$primary-dark-color;
+      }
     }
 
     @include variables.desktop {

--- a/components/Books/BookMenu/BookMenu.module.scss
+++ b/components/Books/BookMenu/BookMenu.module.scss
@@ -19,9 +19,11 @@
   z-index: 1000;
   text-decoration: none;
 
-  &:hover {
-    border: 1px solid variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border: 1px solid variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 
   @include variables.tablet {

--- a/components/Books/ImageZoom/ImageZoom.module.scss
+++ b/components/Books/ImageZoom/ImageZoom.module.scss
@@ -18,9 +18,11 @@
     border: 1px solid variables.$primary-light-color;
     background-color: variables.$primary-medium-color;
 
-    &:hover {
-      border: 1px solid variables.$secondary-color;
-      background-color: variables.$primary-dark-color;
+    @include variables.hover-supported {
+      &:hover {
+        border: 1px solid variables.$secondary-color;
+        background-color: variables.$primary-dark-color;
+      }
     }
   }
 

--- a/components/Dialog/Dialog.module.scss
+++ b/components/Dialog/Dialog.module.scss
@@ -137,9 +137,11 @@
     background-color 0.9s ease-in-out;
   cursor: pointer;
 
-  &:hover {
-    border: 1px solid variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border: 1px solid variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 
   @include variables.desktop {

--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -61,10 +61,12 @@
         color 0.9s ease-in-out,
         border-bottom 0.9s ease-in-out;
 
-      &:hover {
-        padding-bottom: 4px;
-        border-bottom: 1px solid variables.$secondary-color;
-        color: variables.$secondary-color;
+      @include variables.hover-supported {
+        &:hover {
+          padding-bottom: 4px;
+          border-bottom: 1px solid variables.$secondary-color;
+          color: variables.$secondary-color;
+        }
       }
     }
   }
@@ -84,9 +86,11 @@
       background-color 0.9s ease-in-out;
     cursor: pointer;
 
-    &:hover {
-      border: 1px solid variables.$secondary-color;
-      background-color: variables.$primary-dark-color;
+    @include variables.hover-supported {
+      &:hover {
+        border: 1px solid variables.$secondary-color;
+        background-color: variables.$primary-dark-color;
+      }
     }
   }
 

--- a/components/HomePage/History/History.module.scss
+++ b/components/HomePage/History/History.module.scss
@@ -61,9 +61,11 @@
         background-color 0.9s ease-in-out;
       cursor: pointer;
 
-      &:hover {
-        border: 1px solid variables.$secondary-color;
-        background-color: variables.$primary-dark-color;
+      @include variables.hover-supported {
+        &:hover {
+          border: 1px solid variables.$secondary-color;
+          background-color: variables.$primary-dark-color;
+        }
       }
     }
   }
@@ -124,8 +126,10 @@
     }
   }
 
-  &:hover {
-    border: 1px solid variables.$secondary-color;
+  @include variables.hover-supported {
+    &:hover {
+      border: 1px solid variables.$secondary-color;
+    }
   }
 }
 
@@ -136,8 +140,10 @@
   background-color: rgba(44, 46, 47, 0.9);
   transition: background-color 0.9s ease-in-out;
 
-  &:hover {
-    background-color: rgba(29, 31, 32, 0.85);
+  @include variables.hover-supported {
+    &:hover {
+      background-color: rgba(29, 31, 32, 0.85);
+    }
   }
 }
 

--- a/components/HomePage/Resources/Resources.module.scss
+++ b/components/HomePage/Resources/Resources.module.scss
@@ -21,9 +21,11 @@
   border: 1px solid variables.$primary-light-dark-color;
   transition: all 0.9s ease-in-out;
 
-  &:hover {
-    border: 1px solid variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border: 1px solid variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 }
 

--- a/components/HomePage/Tunnellers/Tunnellers.module.scss
+++ b/components/HomePage/Tunnellers/Tunnellers.module.scss
@@ -102,9 +102,11 @@
     font-size: 1.5rem;
   }
 
-  &:hover {
-    border-bottom: 1px solid variables.$secondary-color;
-    color: variables.$secondary-color;
+  @include variables.hover-supported {
+    &:hover {
+      border-bottom: 1px solid variables.$secondary-color;
+      color: variables.$secondary-color;
+    }
   }
 
   @include variables.desktop {

--- a/components/Menu/Menu.module.scss
+++ b/components/Menu/Menu.module.scss
@@ -112,9 +112,11 @@
         color 0.9s ease-in-out,
         background-color 0.9s ease-in-out;
 
-      &:hover {
-        color: variables.$secondary-color;
-        background-color: variables.$primary-light-color;
+      @include variables.hover-supported {
+        &:hover {
+          color: variables.$secondary-color;
+          background-color: variables.$primary-light-color;
+        }
       }
     }
   }
@@ -134,9 +136,11 @@
   rotate: 45deg;
   transition: color 0.9s ease-in-out;
 
-  &:hover {
-    color: variables.$secondary-color;
-    cursor: pointer;
+  @include variables.hover-supported {
+    &:hover {
+      color: variables.$secondary-color;
+      cursor: pointer;
+    }
   }
 }
 
@@ -152,9 +156,11 @@
     color 0.9s ease-in-out,
     background-color 0.9s ease-in-out;
 
-  &:hover {
-    color: variables.$secondary-color;
-    background-color: variables.$primary-light-color;
+  @include variables.hover-supported {
+    &:hover {
+      color: variables.$secondary-color;
+      background-color: variables.$primary-light-color;
+    }
   }
 }
 
@@ -179,11 +185,13 @@
 }
 
 .language-switcher {
+  @include variables.text-link;
+
+  display: inline-block;
   flex-shrink: 0;
   margin-left: variables.$xs-margin;
   font-size: 1rem;
-  font-weight: 500;
-  color: variables.$secondary-color;
+  line-height: 1.2;
   white-space: nowrap;
 }
 

--- a/components/Profile/ProfileDiary/DiaryArmyExperience/DiaryArmyExperience.module.scss
+++ b/components/Profile/ProfileDiary/DiaryArmyExperience/DiaryArmyExperience.module.scss
@@ -24,9 +24,11 @@
     color: variables.$secondary-color;
   }
 
-  &:hover {
-    border: 1px solid variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border: 1px solid variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 
   @include variables.desktop {

--- a/components/Roll/Roll.module.scss
+++ b/components/Roll/Roll.module.scss
@@ -94,9 +94,11 @@
     background-color 0.9s ease-in-out;
   cursor: pointer;
 
-  &:hover {
-    border: 1px solid variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border: 1px solid variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 }
 
@@ -173,9 +175,11 @@
       background-color 0.9s ease-in-out;
     cursor: pointer;
 
-    &:hover {
-      border: 1px solid variables.$secondary-color;
-      background-color: variables.$primary-dark-color;
+    @include variables.hover-supported {
+      &:hover {
+        border: 1px solid variables.$secondary-color;
+        background-color: variables.$primary-dark-color;
+      }
     }
 
     &--active {

--- a/components/Roll/RollAlphabet/RollAlphabet.module.scss
+++ b/components/Roll/RollAlphabet/RollAlphabet.module.scss
@@ -85,9 +85,11 @@
       background-color 0.9s ease-in-out;
     cursor: pointer;
 
-    &:hover {
-      border: 1px solid variables.$secondary-color;
-      background-color: variables.$primary-dark-color;
+    @include variables.hover-supported {
+      &:hover {
+        border: 1px solid variables.$secondary-color;
+        background-color: variables.$primary-dark-color;
+      }
     }
   }
 

--- a/components/Roll/RollNoResults/RollNoResults.module.scss
+++ b/components/Roll/RollNoResults/RollNoResults.module.scss
@@ -30,9 +30,11 @@
       background-color 0.9s ease-in-out;
     cursor: pointer;
 
-    &:hover {
-      border: 1px solid variables.$secondary-color;
-      background-color: variables.$primary-dark-color;
+    @include variables.hover-supported {
+      &:hover {
+        border: 1px solid variables.$secondary-color;
+        background-color: variables.$primary-dark-color;
+      }
     }
   }
 

--- a/components/WorksMap/InfoBar/InfoBar.module.scss
+++ b/components/WorksMap/InfoBar/InfoBar.module.scss
@@ -132,8 +132,10 @@
     line-height: 0.6;
     transition: color 0.9s ease-in-out;
 
-    &:hover {
-      color: variables.$text-color;
+    @include variables.hover-supported {
+      &:hover {
+        color: variables.$text-color;
+      }
     }
   }
 }
@@ -262,9 +264,11 @@
       font-weight: 600;
     }
 
-    &:hover {
-      background-color: variables.$primary-dark-color;
-      border-color: variables.$secondary-color;
+    @include variables.hover-supported {
+      &:hover {
+        background-color: variables.$primary-dark-color;
+        border-color: variables.$secondary-color;
+      }
     }
   }
 
@@ -293,9 +297,11 @@
       border-color 0.9s ease-in-out,
       background-color 0.9s ease-in-out;
 
-    &:hover {
-      background-color: variables.$primary-dark-color;
-      border-color: variables.$secondary-color;
+    @include variables.hover-supported {
+      &:hover {
+        background-color: variables.$primary-dark-color;
+        border-color: variables.$secondary-color;
+      }
     }
   }
 }

--- a/components/WorksMap/MapControls/MapControls.module.scss
+++ b/components/WorksMap/MapControls/MapControls.module.scss
@@ -13,9 +13,11 @@
     border-color 0.9s ease-in-out,
     background-color 0.9s ease-in-out;
 
-  &:hover {
-    border-color: variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border-color: variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 
   &--active {
@@ -24,10 +26,12 @@
     color: variables.$primary-dark-color;
   }
 
-  &--active:hover {
-    background-color: variables.$secondary-color;
-    border-color: variables.$secondary-color;
-    color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &--active:hover {
+      background-color: variables.$secondary-color;
+      border-color: variables.$secondary-color;
+      color: variables.$primary-dark-color;
+    }
   }
 }
 
@@ -72,9 +76,11 @@
     border-color 0.9s ease-in-out,
     background-color 0.9s ease-in-out;
 
-  &:hover:not(:disabled) {
-    background-color: variables.$primary-dark-color;
-    border: 1px solid variables.$secondary-color;
+  @include variables.hover-supported {
+    &:hover:not(:disabled) {
+      background-color: variables.$primary-dark-color;
+      border: 1px solid variables.$secondary-color;
+    }
   }
 
   &:disabled {
@@ -105,9 +111,11 @@
   font: inherit;
   transition: all 0.9s ease-in-out;
 
-  &:hover {
-    border-color: variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border-color: variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 
   &--active {
@@ -116,9 +124,11 @@
     color: variables.$primary-dark-color;
   }
 
-  &--active:hover {
-    background-color: variables.$secondary-color;
-    border-color: variables.$secondary-color;
+  @include variables.hover-supported {
+    &--active:hover {
+      background-color: variables.$secondary-color;
+      border-color: variables.$secondary-color;
+    }
   }
 
   &:disabled {
@@ -270,9 +280,11 @@
     border 0.9s ease-in-out,
     background-color 0.9s ease-in-out;
 
-  &:hover:not(:disabled) {
-    background-color: variables.$primary-dark-color;
-    border-color: variables.$secondary-color;
+  @include variables.hover-supported {
+    &:hover:not(:disabled) {
+      background-color: variables.$primary-dark-color;
+      border-color: variables.$secondary-color;
+    }
   }
 
   &:disabled {

--- a/components/WorksMap/TypeFilter/TypeFilter.module.scss
+++ b/components/WorksMap/TypeFilter/TypeFilter.module.scss
@@ -36,9 +36,11 @@
     border-color 0.9s ease-in-out,
     background-color 0.9s ease-in-out;
 
-  &:hover:not(:disabled) {
-    background-color: variables.$primary-dark-color;
-    border: 1px solid variables.$secondary-color;
+  @include variables.hover-supported {
+    &:hover:not(:disabled) {
+      background-color: variables.$primary-dark-color;
+      border: 1px solid variables.$secondary-color;
+    }
   }
 
   &:disabled {
@@ -75,9 +77,11 @@
     background-color 0.9s ease-in-out,
     color 0.9s ease-in-out;
 
-  &:hover {
-    border-color: variables.$secondary-color;
-    background-color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &:hover {
+      border-color: variables.$secondary-color;
+      background-color: variables.$primary-dark-color;
+    }
   }
 
   &--active {
@@ -86,10 +90,12 @@
     color: variables.$primary-dark-color;
   }
 
-  &--active:hover {
-    background-color: variables.$secondary-color;
-    border-color: variables.$secondary-color;
-    color: variables.$primary-dark-color;
+  @include variables.hover-supported {
+    &--active:hover {
+      background-color: variables.$secondary-color;
+      border-color: variables.$secondary-color;
+      color: variables.$primary-dark-color;
+    }
   }
 
   &--disabled {

--- a/components/WorksMap/WorksMap.module.scss
+++ b/components/WorksMap/WorksMap.module.scss
@@ -51,8 +51,10 @@
     color: variables.$secondary-color !important;
     transition: all 0.9s ease-in-out;
 
-    &:hover {
-      text-decoration: none;
+    @include variables.hover-supported {
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
 


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
`&:hover` is applied for touch device, leaving buttons on `hover` state.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- `hover` is not for pointing device only

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
