### PR TITLE
[NZT-119] Add copy/paste button for work coordinates

### DIFF
--- a/__tests__/unit/components/WorksMap/InfoBar/InfoBar.test.tsx
+++ b/__tests__/unit/components/WorksMap/InfoBar/InfoBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { mockCave } from "__tests__/unit/utils/mocks/mockCave";
 import {
   mockSubway,
@@ -17,6 +17,14 @@ import { CATEGORY_COLORS } from "@/components/WorksMap/utils/markerIcons";
 
 const onClose = jest.fn();
 const colors = CATEGORY_COLORS;
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn().mockResolvedValue("Mocked write text"),
+  },
+});
+
+global.alert = jest.fn();
 
 describe("InfoBar", () => {
   beforeEach(() => {
@@ -349,6 +357,31 @@ describe("InfoBar", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("copies work coordinates to clipboard", async () => {
+    jest.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+    render(
+      <InfoBar
+        work={mockWork}
+        isExiting={false}
+        locale="en"
+        colors={colors}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy to clipboard" }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "50.305000, 2.876000",
+      );
+      expect(window.alert).toHaveBeenCalledWith(
+        "Coordinates have been copied to clipboard",
+      );
+    });
   });
 
   describe("cave card", () => {

--- a/__tests__/unit/components/WorksMap/InfoBar/__snapshots__/InfoBar.test.tsx.snap
+++ b/__tests__/unit/components/WorksMap/InfoBar/__snapshots__/InfoBar.test.tsx.snap
@@ -71,9 +71,26 @@ exports[`InfoBar matches the snapshot 1`] = `
             Coordinates
           </span>
           <span
-            class="info-bar-value"
+            class="info-bar-value-group"
           >
-            50.305000, 2.876000
+            <span
+              class="info-bar-value"
+            >
+              50.305000, 2.876000
+            </span>
+            <button
+              aria-label="Copy to clipboard"
+              class="copy-paste"
+              type="button"
+            >
+              <img
+                alt="Copy to clipboard"
+                height="12"
+                placeholder="empty"
+                src="/copy.png"
+                width="10"
+              />
+            </button>
           </span>
         </div>
       </div>

--- a/components/WorksMap/InfoBar/InfoBar.module.scss
+++ b/components/WorksMap/InfoBar/InfoBar.module.scss
@@ -230,6 +230,23 @@
   font-weight: 400;
 }
 
+.info-bar-value-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.copy-paste {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  transform: translateY(-0.15rem);
+}
+
 .info-bar-nav {
   display: flex;
   flex-direction: column;

--- a/components/WorksMap/InfoBar/InfoBar.module.scss
+++ b/components/WorksMap/InfoBar/InfoBar.module.scss
@@ -280,13 +280,6 @@
       color: variables.$text-color;
       font-weight: 600;
     }
-
-    @include variables.hover-supported {
-      &:hover {
-        background-color: variables.$primary-dark-color;
-        border-color: variables.$secondary-color;
-      }
-    }
   }
 
   button {
@@ -294,7 +287,6 @@
     align-items: center;
     justify-content: center;
     width: 100%;
-    height: 28px;
     padding: 0;
     background-color: variables.$primary-medium-color;
     border: 1px solid variables.$primary-light-color;

--- a/components/WorksMap/InfoBar/InfoBar.tsx
+++ b/components/WorksMap/InfoBar/InfoBar.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 
 import { CaveData } from "@/utils/database/queries/cavesQuery";
@@ -35,6 +36,13 @@ function getAnimClass(
   return isExiting ? styles.exit : styles.enter;
 }
 
+function formatCoordinates(
+  latitude: number | string,
+  longitude: number | string,
+) {
+  return `${Number(latitude).toFixed(6)}, ${Number(longitude).toFixed(6)}`;
+}
+
 export function InfoBar({
   work,
   cave,
@@ -49,6 +57,30 @@ export function InfoBar({
   onNavigate,
 }: Props) {
   const t = useTranslations("maps");
+  const copyCoordinatesLabel =
+    locale === "en" ? "Copy to clipboard" : "Copier dans le presse-papiers";
+
+  const handleCopy = (coordinates: string) => {
+    navigator.clipboard
+      .writeText(coordinates)
+      .then(() => {
+        alert(
+          locale === "en"
+            ? "Coordinates have been copied to clipboard"
+            : "Les coordonnees ont ete copiees dans le presse-papiers",
+        );
+      })
+      .catch((err) => {
+        alert(
+          locale === "en"
+            ? "Failed to copy to clipboard. Please try selecting and copying the text manually."
+            : "Echec de la copie dans le presse-papiers. Veuillez essayer de selectionner et de copier le texte manuellement.",
+        );
+        if (process.env.NODE_ENV === "development") {
+          console.error("Failed to copy: ", err);
+        }
+      });
+  };
 
   if (subway) {
     const name =
@@ -59,6 +91,10 @@ export function InfoBar({
       locale === "fr" ? subway.subway_note_fr : subway.subway_note_en;
     const dateStart = subway.subway_date_start;
     const dateEnd = subway.subway_date_end;
+    const coordinates = formatCoordinates(
+      subway.subway_latitude,
+      subway.subway_longitude,
+    );
     const hasTwoDates = dateStart && dateEnd && dateEnd !== dateStart;
     const [displayStart, displayEnd] =
       hasTwoDates && dateEnd < dateStart
@@ -99,9 +135,22 @@ export function InfoBar({
               <span className={STYLES["info-bar-label"]}>
                 {t("coordinates")}
               </span>
-              <span className={STYLES["info-bar-value"]}>
-                {Number(subway.subway_latitude).toFixed(6)},{" "}
-                {Number(subway.subway_longitude).toFixed(6)}
+              <span className={STYLES["info-bar-value-group"]}>
+                <span className={STYLES["info-bar-value"]}>{coordinates}</span>
+                <button
+                  type="button"
+                  className={STYLES["copy-paste"]}
+                  aria-label={copyCoordinatesLabel}
+                  onClick={() => handleCopy(coordinates)}
+                >
+                  <Image
+                    src="/copy.png"
+                    alt={copyCoordinatesLabel}
+                    width={10}
+                    height={12}
+                    placeholder="empty"
+                  />
+                </button>
               </span>
             </div>
           </div>
@@ -118,6 +167,10 @@ export function InfoBar({
   if (cave) {
     const name = locale === "fr" ? cave.cave_name_fr : cave.cave_name_en;
     const typeLabel = locale === "fr" ? cave.cave_type_fr : cave.cave_type_en;
+    const coordinates = formatCoordinates(
+      cave.cave_latitude,
+      cave.cave_longitude,
+    );
     return (
       <div
         className={`${STYLES["info-bar"]} ${getAnimClass(isExiting, animType, STYLES)}`}
@@ -132,9 +185,22 @@ export function InfoBar({
               <span className={STYLES["info-bar-label"]}>
                 {t("coordinates")}
               </span>
-              <span className={STYLES["info-bar-value"]}>
-                {Number(cave.cave_latitude).toFixed(6)},{" "}
-                {Number(cave.cave_longitude).toFixed(6)}
+              <span className={STYLES["info-bar-value-group"]}>
+                <span className={STYLES["info-bar-value"]}>{coordinates}</span>
+                <button
+                  type="button"
+                  className={STYLES["copy-paste"]}
+                  aria-label={copyCoordinatesLabel}
+                  onClick={() => handleCopy(coordinates)}
+                >
+                  <Image
+                    src="/copy.png"
+                    alt={copyCoordinatesLabel}
+                    width={10}
+                    height={12}
+                    placeholder="empty"
+                  />
+                </button>
               </span>
             </div>
           </div>
@@ -172,6 +238,10 @@ export function InfoBar({
 
   const dateStart = work.work_date_start;
   const dateEnd = work.work_date_end;
+  const coordinates = formatCoordinates(
+    work.work_latitude,
+    work.work_longitude,
+  );
   // End date may be before start due to data entry errors — always display in chronological order
   const hasTwoDates = dateStart && dateEnd && dateEnd !== dateStart;
   const [displayStart, displayEnd] =
@@ -235,9 +305,22 @@ export function InfoBar({
           )}
           <div className={STYLES["info-bar-field"]}>
             <span className={STYLES["info-bar-label"]}>{t("coordinates")}</span>
-            <span className={STYLES["info-bar-value"]}>
-              {Number(work.work_latitude).toFixed(6)},{" "}
-              {Number(work.work_longitude).toFixed(6)}
+            <span className={STYLES["info-bar-value-group"]}>
+              <span className={STYLES["info-bar-value"]}>{coordinates}</span>
+              <button
+                type="button"
+                className={STYLES["copy-paste"]}
+                aria-label={copyCoordinatesLabel}
+                onClick={() => handleCopy(coordinates)}
+              >
+                <Image
+                  src="/copy.png"
+                  alt={copyCoordinatesLabel}
+                  width={10}
+                  height={12}
+                  placeholder="empty"
+                />
+              </button>
             </span>
           </div>
         </div>


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
The InfoCard for a specific works has the geo coordinates. However, it would be good to have the option to copy/paste those coordinates. 

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Add copy/paste for coordinates inside the InfoCard
- Fix nav inside the InfoCard

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
