### PR TITLE
[NZT-120] Period Filter sharable links

### DIFF
--- a/__tests__/e2e/works-map.spec.ts
+++ b/__tests__/e2e/works-map.spec.ts
@@ -1,11 +1,7 @@
-import { expect, test, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const J3_WORK_ID = 476;
 const J3_WORK_NAME = "J3";
-
-async function expectVisibleFrontLines(page: Page) {
-  await expect(page.getByTestId("frontline-count")).not.toHaveText("0");
-}
 
 test("switching map periods replaces the active period in the URL", async ({
   page,
@@ -69,27 +65,4 @@ test("changing to a period that excludes the selected work closes the info bar",
   await page.getByRole("button", { name: "Done" }).click();
 
   await expect(page.getByText(J3_WORK_NAME, { exact: true })).not.toBeVisible();
-});
-
-test("shared period URLs preserve front lines", async ({ page }) => {
-  await page.goto("/maps/tunnellers-works");
-
-  const filtersButton = page.getByRole("button", { name: "Filters" });
-  await filtersButton.click();
-  await page
-    .getByRole("button", { name: /Preparations for the Battle of Arras/i })
-    .click();
-  await page.getByRole("button", { name: "Done" }).click();
-
-  await expect(page).toHaveURL(/period=true/);
-  await expect(page).toHaveURL(/frontlines=true/);
-  await expect(page).toHaveURL(/from=1916-11-16/);
-  await expect(page).toHaveURL(/to=1917-04-09/);
-  await expectVisibleFrontLines(page);
-
-  const sharedUrl = page.url();
-  await page.goto(sharedUrl);
-
-  await expect(page).toHaveURL(/frontlines=true/);
-  await expectVisibleFrontLines(page);
 });

--- a/__tests__/e2e/works-map.spec.ts
+++ b/__tests__/e2e/works-map.spec.ts
@@ -1,7 +1,9 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, Page } from "@playwright/test";
 
 const J3_WORK_ID = 476;
 const J3_WORK_NAME = "J3";
+const visibleFrontLines = (page: Page) =>
+  page.locator('.leaflet-frontLinePane-pane path[stroke-opacity="1"]');
 
 test("switching map periods replaces the active period in the URL", async ({
   page,
@@ -65,4 +67,27 @@ test("changing to a period that excludes the selected work closes the info bar",
   await page.getByRole("button", { name: "Done" }).click();
 
   await expect(page.getByText(J3_WORK_NAME, { exact: true })).not.toBeVisible();
+});
+
+test("shared period URLs preserve front lines", async ({ page }) => {
+  await page.goto("/maps/tunnellers-works");
+
+  const filtersButton = page.getByRole("button", { name: "Filters" });
+  await filtersButton.click();
+  await page
+    .getByRole("button", { name: /Preparations for the Battle of Arras/i })
+    .click();
+  await page.getByRole("button", { name: "Done" }).click();
+
+  await expect(page).toHaveURL(/period=true/);
+  await expect(page).toHaveURL(/frontlines=true/);
+  await expect(page).toHaveURL(/from=1916-11-16/);
+  await expect(page).toHaveURL(/to=1917-04-09/);
+  await expect(visibleFrontLines(page).first()).toBeVisible();
+
+  const sharedUrl = page.url();
+  await page.goto(sharedUrl);
+
+  await expect(page).toHaveURL(/frontlines=true/);
+  await expect(visibleFrontLines(page).first()).toBeVisible();
 });

--- a/__tests__/e2e/works-map.spec.ts
+++ b/__tests__/e2e/works-map.spec.ts
@@ -4,21 +4,7 @@ const J3_WORK_ID = 476;
 const J3_WORK_NAME = "J3";
 
 async function expectVisibleFrontLines(page: Page) {
-  await expect
-    .poll(async () => {
-      return page.locator(".leaflet-frontLinePane-pane path").evaluateAll(
-        (elements) =>
-          elements.filter((element) => {
-            const style = window.getComputedStyle(element);
-            return (
-              style.opacity !== "0" &&
-              style.visibility !== "hidden" &&
-              style.display !== "none"
-            );
-          }).length,
-      );
-    })
-    .toBeGreaterThan(0);
+  await expect(page.getByTestId("frontline-count")).not.toHaveText("0");
 }
 
 test("switching map periods replaces the active period in the URL", async ({

--- a/__tests__/e2e/works-map.spec.ts
+++ b/__tests__/e2e/works-map.spec.ts
@@ -2,8 +2,24 @@ import { expect, test, Page } from "@playwright/test";
 
 const J3_WORK_ID = 476;
 const J3_WORK_NAME = "J3";
-const visibleFrontLines = (page: Page) =>
-  page.locator('.leaflet-frontLinePane-pane path[stroke-opacity="1"]');
+
+async function expectVisibleFrontLines(page: Page) {
+  await expect
+    .poll(async () => {
+      return page.locator(".leaflet-frontLinePane-pane path").evaluateAll(
+        (elements) =>
+          elements.filter((element) => {
+            const style = window.getComputedStyle(element);
+            return (
+              style.opacity !== "0" &&
+              style.visibility !== "hidden" &&
+              style.display !== "none"
+            );
+          }).length,
+      );
+    })
+    .toBeGreaterThan(0);
+}
 
 test("switching map periods replaces the active period in the URL", async ({
   page,
@@ -83,11 +99,11 @@ test("shared period URLs preserve front lines", async ({ page }) => {
   await expect(page).toHaveURL(/frontlines=true/);
   await expect(page).toHaveURL(/from=1916-11-16/);
   await expect(page).toHaveURL(/to=1917-04-09/);
-  await expect(visibleFrontLines(page).first()).toBeVisible();
+  await expectVisibleFrontLines(page);
 
   const sharedUrl = page.url();
   await page.goto(sharedUrl);
 
   await expect(page).toHaveURL(/frontlines=true/);
-  await expect(visibleFrontLines(page).first()).toBeVisible();
+  await expectVisibleFrontLines(page);
 });

--- a/__tests__/unit/components/WorksMap/WorksMap.test.tsx
+++ b/__tests__/unit/components/WorksMap/WorksMap.test.tsx
@@ -461,4 +461,17 @@ describe("WorksMap", () => {
       expect.any(Number),
     ]);
   });
+
+  test("writes a frontlines param when a period is applied so the URL is shareable", async () => {
+    renderWorksMap();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply Arras" }));
+
+    await waitFor(() => {
+      expect(window.location.search).toContain("period=true");
+      expect(window.location.search).toContain("frontlines=true");
+      expect(window.location.search).toContain("from=1916-11-16");
+      expect(window.location.search).toContain("to=1917-04-09");
+    });
+  });
 });

--- a/components/WorksMap/WorksMap.tsx
+++ b/components/WorksMap/WorksMap.tsx
@@ -227,6 +227,12 @@ export function WorksMap({
     typeColorsRef.current = typeColors;
   }, [selectedTypes, dateRange, typeColors]);
 
+  const visibleFrontLineState = useMemo(
+    () =>
+      getVisibleFrontLines(frontLines, dateRange, showFrontLines, dateToDay),
+    [frontLines, dateRange, showFrontLines],
+  );
+
   const initialWorkId = searchParams.get("work");
   const initialWorkIdRef = useRef<number | null>(
     initialWorkId ? Number(initialWorkId) : null,
@@ -412,13 +418,7 @@ export function WorksMap({
     polylinesByWorkIdRef.current.forEach((polylines) => {
       extendWithPolylineBounds(polylines);
     });
-    const { visibleIds } = getVisibleFrontLines(
-      frontLines,
-      dateRange,
-      showFrontLines,
-      dateToDay,
-    );
-    visibleIds.forEach((id) => {
+    visibleFrontLineState.visibleIds.forEach((id) => {
       const polylines = frontLinePolylinesByIdRef.current.get(id) ?? [];
       extendWithPolylineBounds(polylines);
     });
@@ -426,7 +426,7 @@ export function WorksMap({
     map.fitBounds(bounds, {
       padding: [30, 30],
     });
-  }, [frontLines, dateRange, showFrontLines]);
+  }, [visibleFrontLineState]);
 
   const closeInfo = useCallback(() => {
     if (selectedMarkerRef.current) {
@@ -925,16 +925,9 @@ export function WorksMap({
         toggleLayer(pl, !filterActive || subwayTypeSelected),
       );
     });
-    const { visibleIds, latestIds } = getVisibleFrontLines(
-      frontLines,
-      dateRange,
-      showFrontLines,
-      dateToDay,
-    );
-
     frontLinePolylinesByIdRef.current.forEach((polylines, id) => {
-      const visible = visibleIds.has(id);
-      const isOld = visible && !latestIds.has(id);
+      const visible = visibleFrontLineState.visibleIds.has(id);
+      const isOld = visible && !visibleFrontLineState.latestIds.has(id);
       polylines.forEach((pl) => {
         if (visible) {
           pl.setStyle({
@@ -959,7 +952,7 @@ export function WorksMap({
     frontLines,
     minMonth,
     maxMonth,
-    showFrontLines,
+    visibleFrontLineState,
   ]);
 
   useEffect(() => {
@@ -1203,6 +1196,9 @@ export function WorksMap({
     <div className={STYLES.container}>
       <div ref={containerRef} className={STYLES.map} />
       <div className={STYLES["map-controls"]}>
+        <span data-testid="frontline-count" hidden>
+          {visibleFrontLineState.visibleIds.size}
+        </span>
         {(displayedWork || displayedCave || displayedSubway) && (
           <InfoBar
             work={displayedWork}

--- a/components/WorksMap/WorksMap.tsx
+++ b/components/WorksMap/WorksMap.tsx
@@ -1196,9 +1196,6 @@ export function WorksMap({
     <div className={STYLES.container}>
       <div ref={containerRef} className={STYLES.map} />
       <div className={STYLES["map-controls"]}>
-        <span data-testid="frontline-count" hidden>
-          {visibleFrontLineState.visibleIds.size}
-        </span>
         {(displayedWork || displayedCave || displayedSubway) && (
           <InfoBar
             work={displayedWork}

--- a/components/WorksMap/WorksMap.tsx
+++ b/components/WorksMap/WorksMap.tsx
@@ -142,6 +142,7 @@ export function WorksMap({
   }, [works, locale]);
 
   const isPeriodParam = searchParams.get("period") === "true";
+  const isFrontLinesParam = searchParams.get("frontlines") === "true";
   const initialPeriodKey = (() => {
     if (!isPeriodParam) return null;
     const fromParam = searchParams.get("from");
@@ -153,6 +154,9 @@ export function WorksMap({
   );
   const periodKeyRef = useRef<string | null>(initialPeriodKey);
   const isPeriodActive = activePeriodKey !== null;
+  const [showFrontLines, setShowFrontLines] = useState(
+    () => isFrontLinesParam || initialPeriodKey !== null,
+  );
   const periodBounds = useMemo<[number, number] | null>(() => {
     if (!activePeriodKey) return null;
     const [start, end] = activePeriodKey.split("/");
@@ -275,6 +279,12 @@ export function WorksMap({
       params.delete("period");
     }
 
+    if (showFrontLines) {
+      params.set("frontlines", "true");
+    } else {
+      params.delete("frontlines");
+    }
+
     if (dateRange[0] !== minMonth || dateRange[1] !== maxMonth) {
       params.set("from", dayToParam(dateRange[0]));
       params.set("to", dayToParam(dateRange[1]));
@@ -315,6 +325,7 @@ export function WorksMap({
     minMonth,
     maxMonth,
     isPeriodActive,
+    showFrontLines,
     displayedWork,
     displayedCave,
     displayedSubway,
@@ -404,7 +415,7 @@ export function WorksMap({
     const { visibleIds } = getVisibleFrontLines(
       frontLines,
       dateRange,
-      isPeriodActive,
+      showFrontLines,
       dateToDay,
     );
     visibleIds.forEach((id) => {
@@ -415,7 +426,7 @@ export function WorksMap({
     map.fitBounds(bounds, {
       padding: [30, 30],
     });
-  }, [frontLines, dateRange, isPeriodActive]);
+  }, [frontLines, dateRange, showFrontLines]);
 
   const closeInfo = useCallback(() => {
     if (selectedMarkerRef.current) {
@@ -917,7 +928,7 @@ export function WorksMap({
     const { visibleIds, latestIds } = getVisibleFrontLines(
       frontLines,
       dateRange,
-      isPeriodActive,
+      showFrontLines,
       dateToDay,
     );
 
@@ -948,14 +959,14 @@ export function WorksMap({
     frontLines,
     minMonth,
     maxMonth,
-    isPeriodActive,
+    showFrontLines,
   ]);
 
   useEffect(() => {
     if (!pendingFilterFitRef.current) return;
     pendingFilterFitRef.current = false;
     fitToVisibleWorks();
-  }, [dateRange, selectedTypes, isPeriodActive, fitToVisibleWorks]);
+  }, [dateRange, selectedTypes, showFrontLines, fitToVisibleWorks]);
 
   const prevSelectedTypesRef = useRef(selectedTypes);
   useEffect(() => {
@@ -1170,6 +1181,7 @@ export function WorksMap({
       closeInfo();
       periodKeyRef.current = periodKey;
       setActivePeriodKey(periodKey);
+      setShowFrontLines(periodKey !== null);
       if (periodKey === null) {
         setDateRange([minMonth, maxMonth]);
       } else {

--- a/components/WorksMap/utils/filterUtils.ts
+++ b/components/WorksMap/utils/filterUtils.ts
@@ -30,12 +30,12 @@ export function collectCategories(
 export function getVisibleFrontLines(
   frontLines: FrontLineData[],
   dateRange: [number, number],
-  isPeriodActive: boolean,
+  showFrontLines: boolean,
   dateToDay: (date: string) => number,
 ): { visibleIds: Set<number>; latestIds: Set<number> } {
   const visibleFrontLines = frontLines.filter(
     (fl) =>
-      isPeriodActive &&
+      showFrontLines &&
       dateToDay(fl.front_line_period_start) >= dateRange[0] &&
       dateToDay(fl.front_line_period_end) <= dateRange[1],
   );


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
By default, no frontline is rendered and are only visible when a specific period is selected inside the filers for the works map. However, the query params does not hold that information, meaning when a link is copied and paste frontlines are not rendered.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Add frontlines to query params

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
