### PR TITLE
[NZT-121] Fix start date for map

### DIFF
--- a/__tests__/unit/components/WorksMap/WorksMap.test.tsx
+++ b/__tests__/unit/components/WorksMap/WorksMap.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 
+import { dateToDay } from "@/components/WorksMap/utils/mapParams";
 import { WorksMap } from "@/components/WorksMap/WorksMap";
 import { CaveData, CavePathPoint } from "@/utils/database/queries/cavesQuery";
 import {
@@ -473,5 +474,14 @@ describe("WorksMap", () => {
       expect(window.location.search).toContain("from=1916-11-16");
       expect(window.location.search).toContain("to=1917-04-09");
     });
+  });
+
+  test("uses the earliest configured period boundary as the initial start date", () => {
+    renderWorksMap();
+
+    expect(latestMapControlsProps?.dateRange).toEqual([
+      dateToDay("1916-03-16"),
+      expect.any(Number),
+    ]);
   });
 });

--- a/components/WorksMap/MapControls/MapControls.tsx
+++ b/components/WorksMap/MapControls/MapControls.tsx
@@ -6,54 +6,10 @@ import { useState, useEffect, useMemo } from "react";
 import { Dialog } from "@/components/Dialog/Dialog";
 
 import STYLES from "./MapControls.module.scss";
+import { MAP_PERIODS } from "../utils/periods";
 import { TypeFilter } from "../TypeFilter/TypeFilter";
 import { dateToDay, formatPeriodRange } from "../utils/mapParams";
 import { WorksSlider } from "../WorksSlider/WorksSlider";
-
-const PERIODS = [
-  {
-    key: "1916-03-16/1916-11-15",
-    start: "1916-03-16",
-    end: "1916-11-15",
-    en: "Underground Warfare",
-    fr: "Guerre souterraine",
-  },
-  {
-    key: "1916-11-16/1917-04-09",
-    start: "1916-11-16",
-    end: "1917-04-09",
-    en: "Preparations for the Battle of Arras",
-    fr: "Préparatifs de la bataille d'Arras",
-  },
-  {
-    key: "1917-04-10/1918-03-20",
-    start: "1917-04-10",
-    end: "1918-03-20",
-    en: "East of Arras Trench Works",
-    fr: "Travaux de tranchées à l'est d'Arras",
-  },
-  {
-    key: "1918-03-21/1918-07-14",
-    start: "1918-03-21",
-    end: "1918-07-14",
-    en: "1918 German Spring Offensive",
-    fr: "Offensive allemande du printemps 1918",
-  },
-  {
-    key: "1918-07-15/1918-08-21",
-    start: "1918-07-15",
-    end: "1918-08-21",
-    en: "Preparations for the Allied Offensives",
-    fr: "Préparatifs des offensives alliées",
-  },
-  {
-    key: "1918-09-26/1918-12-27",
-    start: "1918-09-26",
-    end: "1918-12-27",
-    en: "Bridging Operations",
-    fr: "Opérations de ponts",
-  },
-];
 
 type Props = {
   visibleCount: number;
@@ -121,7 +77,7 @@ export function MapControls({
   };
 
   const commitPending = (period: string | null, types: Set<string>) => {
-    const p = period ? PERIODS.find((x) => x.key === period) : null;
+    const p = period ? MAP_PERIODS.find((x) => x.key === period) : null;
     onApplyFilters(period, p?.start ?? null, p?.end ?? null, types);
   };
 
@@ -158,7 +114,7 @@ export function MapControls({
 
   const pendingAvailableTypes = useMemo(() => {
     const p = pendingPeriod
-      ? PERIODS.find((x) => x.key === pendingPeriod)
+      ? MAP_PERIODS.find((x) => x.key === pendingPeriod)
       : null;
     return p
       ? computeAvailableTypes(dateToDay(p.start), dateToDay(p.end))
@@ -167,7 +123,7 @@ export function MapControls({
 
   const pendingVisibleCount = useMemo(() => {
     const p = pendingPeriod
-      ? PERIODS.find((x) => x.key === pendingPeriod)
+      ? MAP_PERIODS.find((x) => x.key === pendingPeriod)
       : null;
     const start = p ? dateToDay(p.start) : minMonth;
     const end = p ? dateToDay(p.end) : maxMonth;
@@ -177,7 +133,7 @@ export function MapControls({
   const availablePeriods = useMemo(
     () =>
       new Set(
-        PERIODS.filter(
+        MAP_PERIODS.filter(
           ({ start, end }) =>
             computeVisibleCount(
               dateToDay(start),
@@ -252,7 +208,7 @@ export function MapControls({
           {locale === "fr" ? "Périodes" : "Time periods"}
         </h3>
         <div className={STYLES["dialog-period-grid"]}>
-          {PERIODS.map(({ key, start, end, en, fr }) => (
+          {MAP_PERIODS.map(({ key, start, end, en, fr }) => (
             <button
               key={key}
               className={`${STYLES["period-button"]} ${pendingPeriod === key ? STYLES["period-button--active"] : ""}`}

--- a/components/WorksMap/MapControls/MapControls.tsx
+++ b/components/WorksMap/MapControls/MapControls.tsx
@@ -6,9 +6,9 @@ import { useState, useEffect, useMemo } from "react";
 import { Dialog } from "@/components/Dialog/Dialog";
 
 import STYLES from "./MapControls.module.scss";
-import { MAP_PERIODS } from "../utils/periods";
 import { TypeFilter } from "../TypeFilter/TypeFilter";
 import { dateToDay, formatPeriodRange } from "../utils/mapParams";
+import { MAP_PERIODS } from "../utils/periods";
 import { WorksSlider } from "../WorksSlider/WorksSlider";
 
 type Props = {

--- a/components/WorksMap/WorksMap.tsx
+++ b/components/WorksMap/WorksMap.tsx
@@ -33,6 +33,7 @@ import {
   createWorkIcon,
 } from "./utils/markerIcons";
 import { groupPathsBySegment } from "./utils/pathUtils";
+import { MAP_PERIODS } from "./utils/periods";
 import STYLES from "./WorksMap.module.scss";
 
 // Fix Leaflet default marker icons in Next.js
@@ -100,8 +101,16 @@ export function WorksMap({
       })),
     [works],
   );
-  const minMonth = Math.min(...allMonths.map((m) => m.start));
-  const maxMonth = Math.max(...allMonths.map((m) => m.end));
+  const periodDays = useMemo(
+    () =>
+      MAP_PERIODS.flatMap((period) => [
+        dateToDay(period.start),
+        dateToDay(period.end),
+      ]),
+    [],
+  );
+  const minMonth = Math.min(...allMonths.map((m) => m.start), ...periodDays);
+  const maxMonth = Math.max(...allMonths.map((m) => m.end), ...periodDays);
 
   const { types, typeColors, nameToSlug, slugToName } = useMemo(() => {
     const categorySet = new Set<string>();

--- a/components/WorksMap/utils/periods.ts
+++ b/components/WorksMap/utils/periods.ts
@@ -1,0 +1,44 @@
+export const MAP_PERIODS = [
+  {
+    key: "1916-03-16/1916-11-15",
+    start: "1916-03-16",
+    end: "1916-11-15",
+    en: "Underground Warfare",
+    fr: "Guerre souterraine",
+  },
+  {
+    key: "1916-11-16/1917-04-09",
+    start: "1916-11-16",
+    end: "1917-04-09",
+    en: "Preparations for the Battle of Arras",
+    fr: "Préparatifs de la bataille d'Arras",
+  },
+  {
+    key: "1917-04-10/1918-03-20",
+    start: "1917-04-10",
+    end: "1918-03-20",
+    en: "East of Arras Trench Works",
+    fr: "Travaux de tranchées à l'est d'Arras",
+  },
+  {
+    key: "1918-03-21/1918-07-14",
+    start: "1918-03-21",
+    end: "1918-07-14",
+    en: "1918 German Spring Offensive",
+    fr: "Offensive allemande du printemps 1918",
+  },
+  {
+    key: "1918-07-15/1918-08-21",
+    start: "1918-07-15",
+    end: "1918-08-21",
+    en: "Preparations for the Allied Offensives",
+    fr: "Préparatifs des offensives alliées",
+  },
+  {
+    key: "1918-09-26/1918-12-27",
+    start: "1918-09-26",
+    end: "1918-12-27",
+    en: "Bridging Operations",
+    fr: "Opérations de ponts",
+  },
+] as const;


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
The map is currently showing as start date the earliest work, despite having a period which starts before that date.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Align map start date with the first period.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
