### PR TITLE
[NZT-123] Fix Map issues

### DIFF
--- a/__tests__/unit/components/WorksMap/MapControls.test.tsx
+++ b/__tests__/unit/components/WorksMap/MapControls.test.tsx
@@ -114,6 +114,7 @@ describe("MapControls", () => {
         onZoom={jest.fn()}
         totalWorks={10}
         periodBounds={null}
+        clampBounds={null}
       />,
     );
   }
@@ -155,6 +156,18 @@ describe("MapControls", () => {
       screen.getByRole("button", { name: /Underground Warfare/i }),
     );
     expect(toggle).toHaveTextContent("Filters2");
+  });
+
+  test("does not count selected types that are unavailable in the current period", () => {
+    renderMapControls({
+      selectedTypes: new Set(["Dugout"]),
+      initialPeriodKey: "1916-03-16/1916-11-15",
+      computeAvailableTypes: () => new Set<string>(),
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Toggle filters" }),
+    ).toHaveTextContent("Filters1");
   });
 
   test("disables periods that have no matching work for the selected pending type", () => {

--- a/__tests__/unit/components/WorksMap/TypeFilter/__snapshots__/TypeFilter.test.tsx.snap
+++ b/__tests__/unit/components/WorksMap/TypeFilter/__snapshots__/TypeFilter.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TypeFilter matches the snapshot 1`] = `
   >
     <button
       aria-pressed="false"
-      class="chip  "
+      class="chip"
     >
       <span
         class="chip-dot"
@@ -19,7 +19,7 @@ exports[`TypeFilter matches the snapshot 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="chip  "
+      class="chip"
     >
       <span
         class="chip-dot"
@@ -29,7 +29,7 @@ exports[`TypeFilter matches the snapshot 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="chip  "
+      class="chip"
     >
       <span
         class="chip-dot"

--- a/__tests__/unit/components/WorksMap/WorksMap.test.tsx
+++ b/__tests__/unit/components/WorksMap/WorksMap.test.tsx
@@ -80,6 +80,20 @@ jest.mock("../../../../components/WorksMap/MapControls/MapControls", () => ({
         >
           Apply Allied Offensives
         </button>
+        <button
+          onClick={() =>
+            (
+              props.onApplyFilters as (
+                _periodKey: string | null,
+                _periodStart: string | null,
+                _periodEnd: string | null,
+                _types: Set<string>,
+              ) => void
+            )(null, null, null, new Set(["Dugout"]))
+          }
+        >
+          Apply Dugout
+        </button>
       </div>
     );
   },
@@ -483,5 +497,22 @@ describe("WorksMap", () => {
       dateToDay("1916-03-16"),
       expect.any(Number),
     ]);
+  });
+
+  test("type-only filters snap the slider range to matching work dates", async () => {
+    renderWorksMap();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply Dugout" }));
+
+    await waitFor(() => {
+      expect(latestMapControlsProps?.dateRange).toEqual([
+        dateToDay("1916-11-16"),
+        dateToDay("1918-09-26"),
+      ]);
+      expect(latestMapControlsProps?.clampBounds).toEqual([
+        dateToDay("1916-11-16"),
+        dateToDay("1918-09-26"),
+      ]);
+    });
   });
 });

--- a/components/WorksMap/MapControls/MapControls.tsx
+++ b/components/WorksMap/MapControls/MapControls.tsx
@@ -39,6 +39,7 @@ type Props = {
   onZoom: (_dir: 1 | -1) => void;
   totalWorks: number;
   periodBounds: [number, number] | null;
+  clampBounds: [number, number] | null;
 };
 
 export function MapControls({
@@ -60,6 +61,7 @@ export function MapControls({
   onZoom,
   totalWorks,
   periodBounds,
+  clampBounds,
 }: Props) {
   const t = useTranslations("maps");
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
@@ -130,6 +132,12 @@ export function MapControls({
     return computeVisibleCount(start, end, pendingTypes);
   }, [pendingPeriod, pendingTypes, computeVisibleCount, minMonth, maxMonth]);
 
+  const activeAvailableTypes = useMemo(() => {
+    const start = periodBounds?.[0] ?? minMonth;
+    const end = periodBounds?.[1] ?? maxMonth;
+    return computeAvailableTypes(start, end);
+  }, [computeAvailableTypes, periodBounds, minMonth, maxMonth]);
+
   const availablePeriods = useMemo(
     () =>
       new Set(
@@ -152,7 +160,11 @@ export function MapControls({
     setPendingTypes(new Set());
   };
 
-  const activeFilterCount = (initialPeriodKey ? 1 : 0) + selectedTypes.size;
+  const activeSelectedTypeCount = Array.from(selectedTypes).filter((type) =>
+    activeAvailableTypes.has(type),
+  ).length;
+  const activeFilterCount =
+    (initialPeriodKey ? 1 : 0) + activeSelectedTypeCount;
 
   const filtersToggleButton = (
     <button
@@ -260,8 +272,8 @@ export function MapControls({
           onChangeComplete={onDateRangeComplete}
           minMonth={minMonth}
           maxMonth={maxMonth}
-          clampMin={periodBounds?.[0]}
-          clampMax={periodBounds?.[1]}
+          clampMin={clampBounds?.[0]}
+          clampMax={clampBounds?.[1]}
         />
       </>
     );
@@ -279,8 +291,8 @@ export function MapControls({
             onChangeComplete={onDateRangeComplete}
             minMonth={minMonth}
             maxMonth={maxMonth}
-            clampMin={periodBounds?.[0]}
-            clampMax={periodBounds?.[1]}
+            clampMin={clampBounds?.[0]}
+            clampMax={clampBounds?.[1]}
           />
         </div>
         <button

--- a/components/WorksMap/TypeFilter/TypeFilter.module.scss
+++ b/components/WorksMap/TypeFilter/TypeFilter.module.scss
@@ -102,6 +102,12 @@
     opacity: 0.35;
     cursor: not-allowed;
   }
+
+  &--inactive-selected {
+    background-color: variables.$primary-medium-color;
+    border-color: variables.$primary-light-color;
+    color: variables.$secondary-color;
+  }
 }
 
 .chip-dot {

--- a/components/WorksMap/TypeFilter/TypeFilter.tsx
+++ b/components/WorksMap/TypeFilter/TypeFilter.tsx
@@ -23,10 +23,19 @@ export function TypeFilter({
     const isActive = selectedTypes.has(type);
     const isDisabled =
       availableTypes !== undefined && !availableTypes.has(type);
+    const isInactiveSelected = isActive && isDisabled;
+    const className = [
+      STYLES.chip,
+      isActive ? STYLES["chip--active"] : null,
+      isDisabled ? STYLES["chip--disabled"] : null,
+      isInactiveSelected ? STYLES["chip--inactive-selected"] : null,
+    ]
+      .filter(Boolean)
+      .join(" ");
     return (
       <button
         key={type}
-        className={`${STYLES.chip} ${isActive ? STYLES["chip--active"] : ""} ${isDisabled ? STYLES["chip--disabled"] : ""}`}
+        className={className}
         aria-pressed={isActive}
         disabled={isDisabled}
         onClick={() => onToggle(type)}

--- a/components/WorksMap/WorksMap.tsx
+++ b/components/WorksMap/WorksMap.tsx
@@ -1173,6 +1173,36 @@ export function WorksMap({
     [works, allMonths, locale],
   );
 
+  const computeTypeBounds = useCallback(
+    (types: Set<string>): [number, number] | null => {
+      if (types.size === 0) return null;
+
+      const matchingRanges = works
+        .map((work, index) => {
+          const [cat1, cat2] = getWorkCategories(work, locale);
+          const matches =
+            (cat1 !== null && types.has(cat1)) ||
+            (cat2 !== null && types.has(cat2));
+          return matches ? allMonths[index] : null;
+        })
+        .filter((range): range is (typeof allMonths)[number] => range !== null);
+
+      if (matchingRanges.length === 0) return null;
+
+      return [
+        Math.min(...matchingRanges.map((range) => range.start)),
+        Math.max(...matchingRanges.map((range) => range.end)),
+      ];
+    },
+    [works, allMonths, locale],
+  );
+
+  const typeBounds = useMemo<[number, number] | null>(
+    () => computeTypeBounds(selectedTypes),
+    [computeTypeBounds, selectedTypes],
+  );
+  const clampBounds = periodBounds ?? typeBounds;
+
   const handleApplyFilters = useCallback(
     (
       periodKey: string | null,
@@ -1185,7 +1215,8 @@ export function WorksMap({
       setActivePeriodKey(periodKey);
       setShowFrontLines(periodKey !== null);
       if (periodKey === null) {
-        setDateRange([minMonth, maxMonth]);
+        const typeBounds = computeTypeBounds(types);
+        setDateRange(typeBounds ?? [minMonth, maxMonth]);
       } else {
         const pMin = dateToDay(periodStart!);
         const pMax = dateToDay(periodEnd!);
@@ -1194,7 +1225,7 @@ export function WorksMap({
       setSelectedTypes(types);
       pendingFilterFitRef.current = true;
     },
-    [closeInfo, minMonth, maxMonth],
+    [closeInfo, minMonth, maxMonth, computeTypeBounds],
   );
 
   const zoom = useCallback((dir: 1 | -1) => {
@@ -1233,6 +1264,7 @@ export function WorksMap({
           maxMonth={maxMonth}
           initialPeriodKey={initialPeriodKey}
           periodBounds={periodBounds}
+          clampBounds={clampBounds}
           onApplyFilters={handleApplyFilters}
           computeAvailableTypes={computeAvailableTypes}
           computeVisibleCount={computeVisibleCount}


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
We noticed a few incoherence with the filters for the map.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- type-only filters reset the slider to the matching work date range
- type-only filters also clamp the slider so users can’t drag back outside those matching dates
- selected type chips that become unavailable in a chosen period no longer keep the strong selected fill
- when those types become valid again in another period, they correctly return to the selected style
- the filters badge now counts only active filters that actually apply in the current period, instead of counting
  preserved-but-unavailable types

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
