### PR TITLE
[NZT-130] Refactor Roll

### DIFF
--- a/__tests__/unit/components/Roll/RollFilter/RollFilter.test.tsx
+++ b/__tests__/unit/components/Roll/RollFilter/RollFilter.test.tsx
@@ -8,7 +8,7 @@ const defaultProps = {
     { id: 1, label: "Main Body" },
     { id: 2, label: "1st Reinforcements" },
   ],
-  uniquecorps: [
+  uniqueCorps: [
     { id: null, label: "Tunnelling Corps" },
     { id: 5, label: "Engineers" },
   ],
@@ -50,8 +50,8 @@ const defaultProps = {
   handleBirthSliderChange: jest.fn(),
   handleDeathSliderChange: jest.fn(),
   handleRankFilter: jest.fn(),
-  handleUnknwonBirthYear: jest.fn(),
-  handleUnknwonDeathYear: jest.fn(),
+  handleUnknownBirthYear: jest.fn(),
+  handleUnknownDeathYear: jest.fn(),
 };
 
 describe("RollFilter", () => {
@@ -126,17 +126,17 @@ describe("RollFilter", () => {
     });
   });
 
-  test("calls handleUnknwonBirthYear when the unknown birth year checkbox is clicked", () => {
+  test("calls handleUnknownBirthYear when the unknown birth year checkbox is clicked", () => {
     render(<RollFilter {...defaultProps} />);
     const checkbox = screen.getByLabelText("Unknown birth year");
     fireEvent.click(checkbox);
-    expect(defaultProps.handleUnknwonBirthYear).toHaveBeenCalledWith("unknown");
+    expect(defaultProps.handleUnknownBirthYear).toHaveBeenCalledWith("unknown");
   });
 
-  test("calls handleUnknwonDeathYear when the unknown death year checkbox is clicked", () => {
+  test("calls handleUnknownDeathYear when the unknown death year checkbox is clicked", () => {
     render(<RollFilter {...defaultProps} />);
     const checkbox = screen.getByLabelText("Unknown death year");
     fireEvent.click(checkbox);
-    expect(defaultProps.handleUnknwonDeathYear).toHaveBeenCalledWith("unknown");
+    expect(defaultProps.handleUnknownDeathYear).toHaveBeenCalledWith("unknown");
   });
 });

--- a/components/Roll/Roll.tsx
+++ b/components/Roll/Roll.tsx
@@ -1,36 +1,16 @@
 "use client";
 
-import isEqual from "lodash/isEqual";
-import { useSearchParams, useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { useRollState } from "@/components/Roll/hooks/useRollState";
 import { RollAlphabet } from "@/components/Roll/RollAlphabet/RollAlphabet";
 import { RollFilter } from "@/components/Roll/RollFilter/RollFilter";
 import { RollNoResults } from "@/components/Roll/RollNoResults/RollNoResults";
 import { Title } from "@/components/Title/Title";
 import { Tunneller } from "@/types/tunnellers";
-import {
-  type FilterLookups,
-  type Filters,
-  type RollSortOrder,
-  filtersToSearchParams,
-  searchParamsToFilters,
-} from "@/utils/helpers/rollParams";
 import { useWindowDimensions } from "@/utils/helpers/useWindowDimensions";
 
 import STYLES from "./Roll.module.scss";
-import { getUniqueCorps, getUniqueCorpsEn } from "./utils/corpsUtils";
-import {
-  getUniqueDetachments,
-  getUniqueDetachmentsEn,
-} from "./utils/detachmentUtils";
-import {
-  getSortedRanks,
-  getUniqueRanks,
-  getUniqueRanksEn,
-} from "./utils/rankUtils";
-import { getUniqueBirthYears, getUniqueDeathYears } from "./utils/yearsUtils";
 import { Dialog } from "../Dialog/Dialog";
 
 type Props = {
@@ -41,393 +21,22 @@ export function Roll({ tunnellers }: Props) {
   const t = useTranslations("roll");
   const locale = useLocale();
   const { width } = useWindowDimensions();
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const isFirstRenderRef = useRef(true);
-  const previousSearchParamsRef = useRef(searchParams.toString());
-
-  /** ---- Derived data ---- */
-  const tunnellersList = useMemo(
-    () => Object.entries(tunnellers),
-    [tunnellers],
-  );
-  const uniqueDetachments = useMemo(
-    () => getUniqueDetachments(tunnellersList),
-    [tunnellersList],
-  );
-  const uniqueCorps = useMemo(
-    () => getUniqueCorps(tunnellersList),
-    [tunnellersList],
-  );
-  const uniqueRanks = useMemo(
-    () => getUniqueRanks(tunnellersList),
-    [tunnellersList],
-  );
-  const sortedRanks = useMemo(
-    () => getSortedRanks(uniqueRanks, locale as "en" | "fr"),
-    [uniqueRanks, locale],
-  );
-  const uniqueBirthYears = useMemo(
-    () => getUniqueBirthYears(tunnellersList),
-    [tunnellersList],
-  );
-  const uniqueDeathYears = useMemo(
-    () => getUniqueDeathYears(tunnellersList),
-    [tunnellersList],
-  );
-  const uniqueDetachmentsEn = useMemo(
-    () => getUniqueDetachmentsEn(tunnellersList),
-    [tunnellersList],
-  );
-  const uniqueCorpsEn = useMemo(
-    () => getUniqueCorpsEn(tunnellersList),
-    [tunnellersList],
-  );
-  const uniqueRanksEn = useMemo(
-    () => getUniqueRanksEn(tunnellersList),
-    [tunnellersList],
-  );
-  const sortedRanksEn = useMemo(
-    () => getSortedRanks(uniqueRanksEn, "en"),
-    [uniqueRanksEn],
-  );
-
-  /** ---- Defaults ---- */
-  const defaultFilters: Filters = useMemo(
-    () => ({
-      detachment: [],
-      corps: [],
-      ranks: {
-        Officers: [],
-        "Non-Commissioned Officers": [],
-        "Other Ranks": [],
-      },
-      birthYear: uniqueBirthYears,
-      unknownBirthYear: "unknown",
-      deathYear: uniqueDeathYears,
-      unknownDeathYear: "unknown",
-    }),
-    [uniqueBirthYears, uniqueDeathYears],
-  );
-
-  /** ---- Filter lookups for URL slug conversion ---- */
-  const filterLookups: FilterLookups = useMemo(
-    () => ({
-      detachments: uniqueDetachmentsEn,
-      corps: uniqueCorpsEn,
-      sortedRanks: sortedRanksEn,
-      birthYears: uniqueBirthYears,
-      deathYears: uniqueDeathYears,
-    }),
-    [
-      uniqueDetachmentsEn,
-      uniqueCorpsEn,
-      sortedRanksEn,
-      uniqueBirthYears,
-      uniqueDeathYears,
-    ],
-  );
-
-  /** ---- URL-derived state ---- */
-  const parsedUrlState = useMemo(
-    () => searchParamsToFilters(searchParams, filterLookups),
-    [searchParams, filterLookups],
-  );
-
-  const [filters, setFilters] = useState<Filters>(parsedUrlState.filters);
-  const [currentPage, setCurrentPage] = useState<number>(parsedUrlState.page);
-  const [sortOrder, setSortOrder] = useState<RollSortOrder>(
-    parsedUrlState.sortOrder,
-  );
-  const searchParamsString = searchParams.toString();
-
-  /** ---- Re-sync local state when URL changes after mount ---- */
-  useEffect(() => {
-    if (previousSearchParamsRef.current === searchParamsString) return;
-    previousSearchParamsRef.current = searchParamsString;
-    let cancelled = false;
-
-    queueMicrotask(() => {
-      if (cancelled) return;
-
-      if (!isEqual(filters, parsedUrlState.filters)) {
-        setFilters(parsedUrlState.filters);
-      }
-      if (currentPage !== parsedUrlState.page) {
-        setCurrentPage(parsedUrlState.page);
-      }
-      if (sortOrder !== parsedUrlState.sortOrder) {
-        setSortOrder(parsedUrlState.sortOrder);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [searchParamsString, parsedUrlState, filters, currentPage, sortOrder]);
-
-  /** ---- Sync URL params when state changes ---- */
-  useEffect(() => {
-    if (isFirstRenderRef.current) {
-      isFirstRenderRef.current = false;
-      return;
-    }
-    const qs = filtersToSearchParams(
-      filters,
-      currentPage,
-      sortOrder,
-      filterLookups,
-    );
-    const currentQs = window.location.search.replace(/^\?/, "");
-    if (qs === currentQs) return;
-    router.replace(`?${qs}`, { scroll: false });
-  }, [filters, currentPage, router, filterLookups, sortOrder]);
-
-  /** ---- Restore scroll position on mount ---- */
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const raw = localStorage.getItem("roll:scrollY");
-    const y = raw ? Number(raw) : 0;
-    if (Number.isFinite(y)) {
-      requestAnimationFrame(() => window.scrollTo(0, y));
-    }
-  }, []);
-
-  /** ---- Helpers ---- */
-  const hasAnyActiveFilter = (f: Filters): boolean => {
-    const ranksActive = Object.values(f.ranks ?? {}).some((arr) => arr.length);
-    const detachmentActive = (f.detachment ?? []).length > 0;
-    const corpsActive = (f.corps ?? []).length > 0;
-    const birthActive =
-      (f.birthYear ?? []).length > 0 || f.unknownBirthYear === "unknown";
-    const deathActive =
-      (f.deathYear ?? []).length > 0 || f.unknownDeathYear === "unknown";
-    return (
-      ranksActive ||
-      detachmentActive ||
-      corpsActive ||
-      birthActive ||
-      deathActive
-    );
-  };
-
-  const activeFilterCount = [
-    Object.values(filters.ranks ?? {}).some((arr) => arr.length),
-    (filters.detachment ?? []).length > 0,
-    (filters.corps ?? []).length > 0,
-    (filters.birthYear ?? []).length < uniqueBirthYears.length ||
-      filters.unknownBirthYear === "",
-    (filters.deathYear ?? []).length < uniqueDeathYears.length ||
-      filters.unknownDeathYear === "",
-  ].filter(Boolean).length;
-
-  /** ---- Filtering ---- */
-  const filteredGroups: [string, Tunneller[]][] = useMemo(() => {
-    if (!hasAnyActiveFilter(filters)) return [];
-    return tunnellersList
-      .map<[string, Tunneller[]]>(([group, list]) => [
-        group,
-        list
-          .filter(
-            (t) =>
-              !filters.detachment?.length ||
-              filters.detachment.includes(t.detachmentId),
-          )
-          .filter((t) => {
-            if (!filters.corps?.length) return true;
-            return filters.corps.includes(t.corpsId);
-          })
-          .filter((t) => {
-            const r = filters.ranks;
-            if (!r || Object.values(r).every((arr) => arr.length === 0))
-              return true;
-            return Object.values(r).some((arr) => arr.includes(t.rankId));
-          })
-          .filter((t) => {
-            const wantsUnknown = filters.unknownBirthYear === "unknown";
-            const list = filters.birthYear ?? [];
-            if (wantsUnknown && t.birthYear === null) return true;
-            if (list.length && t.birthYear) return list.includes(t.birthYear);
-            return !wantsUnknown && list.length === 0;
-          })
-          .filter((t) => {
-            const wantsUnknown = filters.unknownDeathYear === "unknown";
-            const list = filters.deathYear ?? [];
-            if (wantsUnknown && t.deathYear === null) return true;
-            if (list.length && t.deathYear) return list.includes(t.deathYear);
-            return !wantsUnknown && list.length === 0;
-          }),
-      ])
-      .filter(([, list]) => list.length > 0);
-  }, [filters, tunnellersList]);
-
-  const totalFilteredTunnellers = useMemo(
-    () => filteredGroups.reduce((acc, [, list]) => acc + list.length, 0),
-    [filteredGroups],
-  );
-  const sortedFilteredGroups = useMemo<[string, Tunneller[]][]>(() => {
-    const direction = sortOrder === "asc" ? 1 : -1;
-
-    return [...filteredGroups]
-      .sort(([groupA], [groupB]) => groupA.localeCompare(groupB) * direction)
-      .map<[string, Tunneller[]]>(([group, list]) => [
-        group,
-        [...list].sort((a, b) => {
-          const surnameCompare =
-            a.name.surname.localeCompare(b.name.surname) * direction;
-          if (surnameCompare !== 0) return surnameCompare;
-          return a.name.forename.localeCompare(b.name.forename) * direction;
-        }),
-      ]);
-  }, [filteredGroups, sortOrder]);
-  const totalTunnellers = useMemo(
-    () => tunnellersList.reduce((acc, [, list]) => acc + list.length, 0),
-    [tunnellersList],
-  );
-
-  const startBirthYear = filters.birthYear?.[0];
-  const endBirthYear = filters.birthYear?.[filters.birthYear.length - 1];
-  const startDeathYear = filters.deathYear?.[0];
-  const endDeathYear = filters.deathYear?.[filters.deathYear.length - 1];
-
-  /** ---- Handlers ---- */
-  const setPageToFirst = useCallback(() => setCurrentPage(1), []);
-
-  const handleDetachmentFilter = useCallback(
-    (detachmentId: number | null) => {
-      setFilters((prev) => {
-        const det = new Set(prev.detachment ?? []);
-        det.has(detachmentId)
-          ? det.delete(detachmentId)
-          : det.add(detachmentId);
-        return { ...prev, detachment: Array.from(det) };
-      });
-      setPageToFirst();
-    },
-    [setPageToFirst],
-  );
-
-  const handleCorpsFilter = useCallback(
-    (corpsId: number | null) => {
-      setFilters((prev) => {
-        const set = new Set(prev.corps ?? []);
-        set.has(corpsId) ? set.delete(corpsId) : set.add(corpsId);
-        return { ...prev, corps: Array.from(set) };
-      });
-      setPageToFirst();
-    },
-    [setPageToFirst],
-  );
-
-  const handleBirthSliderChange = useCallback(
-    (value: number | number[]) => {
-      if (!Array.isArray(value)) return;
-      const [start, end] = value;
-      setFilters((prev) => ({
-        ...prev,
-        birthYear: uniqueBirthYears.filter(
-          (y) => y >= String(start) && y <= String(end),
-        ),
-      }));
-      setPageToFirst();
-    },
-    [uniqueBirthYears, setPageToFirst],
-  );
-
-  const handleUnknwonBirthYear = useCallback(
-    (unknown: string) => {
-      setFilters((prev) => ({
-        ...prev,
-        unknownBirthYear: unknown ? "unknown" : "",
-      }));
-      setPageToFirst();
-    },
-    [setPageToFirst],
-  );
-
-  const handleDeathSliderChange = useCallback(
-    (value: number | number[]) => {
-      if (!Array.isArray(value)) return;
-      const [start, end] = value;
-      setFilters((prev) => ({
-        ...prev,
-        deathYear: uniqueDeathYears.filter(
-          (y) => y >= String(start) && y <= String(end),
-        ),
-      }));
-      setPageToFirst();
-    },
-    [uniqueDeathYears, setPageToFirst],
-  );
-
-  const handleUnknwonDeathYear = useCallback(
-    (unknown: string) => {
-      setFilters((prev) => ({
-        ...prev,
-        unknownDeathYear: unknown ? "unknown" : "",
-      }));
-      setPageToFirst();
-    },
-    [setPageToFirst],
-  );
-
-  const handleRankFilter = useCallback(
-    (ranksFilter: Record<string, (number | null)[]>) => {
-      setFilters((prev) => {
-        const nextRanks: Record<string, (number | null)[]> = { ...prev.ranks };
-        Object.entries(ranksFilter).forEach(([category, rankIds]) => {
-          const set = new Set(nextRanks[category] ?? []);
-          const allSelected = rankIds.every((id) => set.has(id));
-          if (allSelected) {
-            rankIds.forEach((id) => set.delete(id));
-          } else {
-            rankIds.forEach((id) => set.add(id));
-          }
-          nextRanks[category] = Array.from(set);
-        });
-        return { ...prev, ranks: nextRanks };
-      });
-      setPageToFirst();
-    },
-    [setPageToFirst],
-  );
-
-  const handleResetFilters = useCallback(() => {
-    if (!isEqual(filters, defaultFilters)) {
-      setCurrentPage(1);
-      setFilters(defaultFilters);
-    }
-  }, [filters, defaultFilters]);
-
-  /** ---- Dialog state ---- */
-  const [isOpen, setIsOpen] = useState(false);
-  const onClose = useCallback(() => setIsOpen(false), []);
-  const handleFilterButton = useCallback(() => setIsOpen(true), []);
-  const handleSortToggle = useCallback(() => {
-    setCurrentPage(1);
-    setSortOrder((current) => (current === "asc" ? "desc" : "asc"));
-  }, []);
-
-  const rollFiltersProps = {
-    className: STYLES["filters-container"],
-    uniqueDetachments,
-    uniquecorps: uniqueCorps,
-    uniqueBirthYears,
-    uniqueDeathYears,
-    sortedRanks,
-    filters,
-    startBirthYear,
-    endBirthYear,
-    startDeathYear,
-    endDeathYear,
-    handleDetachmentFilter,
-    handleCorpsFilter,
-    handleBirthSliderChange,
-    handleDeathSliderChange,
-    handleRankFilter,
-    handleUnknwonBirthYear,
-    handleUnknwonDeathYear,
-  };
+  const {
+    currentPage,
+    setCurrentPage,
+    sortOrder,
+    isDialogOpen,
+    closeDialog,
+    openDialog,
+    handleSortToggle,
+    rollFiltersProps,
+    activeFilterCount,
+    filteredGroups,
+    sortedFilteredGroups,
+    totalFilteredTunnellers,
+    totalTunnellers,
+    handleResetFilters,
+  } = useRollState({ tunnellers, locale });
 
   const isDesktop = () => (width ? width > 896 : false);
   const desktopView = isDesktop();
@@ -443,15 +52,18 @@ export function Roll({ tunnellers }: Props) {
       <Dialog
         id="filter-dialog"
         isFooterEnabled={true}
-        isOpen={isOpen}
+        isOpen={isDialogOpen}
         handleResetFilters={handleResetFilters}
         hasActiveFilters={activeFilterCount > 0}
-        onClose={onClose}
+        onClose={closeDialog}
         title={t("filters")}
         totalFiltered={totalFilteredTunnellers}
         total={totalTunnellers}
       >
-        <RollFilter {...rollFiltersProps} />
+        <RollFilter
+          className={STYLES["filters-container"]}
+          {...rollFiltersProps}
+        />
       </Dialog>
       <div className={STYLES.container}>
         <div className={STYLES.header}>
@@ -511,7 +123,7 @@ export function Roll({ tunnellers }: Props) {
                   </button>
                   <button
                     className={`${STYLES["filter-button"]} ${activeFilterCount > 0 ? STYLES["filter-button--active"] : ""}`}
-                    onClick={handleFilterButton}
+                    onClick={openDialog}
                   >
                     {t("filters")}
                     {activeFilterCount > 0 && (
@@ -526,7 +138,7 @@ export function Roll({ tunnellers }: Props) {
             {desktopView ? (
               <button
                 className={`${STYLES["filter-button"]} ${activeFilterCount > 0 ? STYLES["filter-button--active"] : ""}`}
-                onClick={handleFilterButton}
+                onClick={openDialog}
               >
                 {t("filters")}
                 {activeFilterCount > 0 && (
@@ -536,7 +148,12 @@ export function Roll({ tunnellers }: Props) {
                 )}
               </button>
             ) : null}
-            {desktopView ? <RollFilter {...rollFiltersProps} /> : null}
+            {desktopView ? (
+              <RollFilter
+                className={STYLES["filters-container"]}
+                {...rollFiltersProps}
+              />
+            ) : null}
           </div>
 
           {filteredGroups.length > 0 ? (

--- a/components/Roll/RollFilter/RollFilter.tsx
+++ b/components/Roll/RollFilter/RollFilter.tsx
@@ -13,7 +13,7 @@ import { rankCategoryTranslationKey } from "../utils/rankUtils";
 type Props = {
   className: string;
   uniqueDetachments: FilterOption[];
-  uniquecorps: FilterOption[];
+  uniqueCorps: FilterOption[];
   uniqueBirthYears: string[];
   uniqueDeathYears: string[];
   sortedRanks: {
@@ -39,14 +39,14 @@ type Props = {
   handleBirthSliderChange: (value: number | number[]) => void;
   handleDeathSliderChange: (value: number | number[]) => void;
   handleRankFilter: (rank: { [key: string]: (number | null)[] }) => void;
-  handleUnknwonBirthYear: (unknownBirthYear: string) => void;
-  handleUnknwonDeathYear: (unknownDeathYear: string) => void;
+  handleUnknownBirthYear: (unknownBirthYear: string) => void;
+  handleUnknownDeathYear: (unknownDeathYear: string) => void;
 };
 
 export function RollFilter({
   className,
   uniqueDetachments,
-  uniquecorps,
+  uniqueCorps,
   uniqueBirthYears,
   uniqueDeathYears,
   sortedRanks,
@@ -60,8 +60,8 @@ export function RollFilter({
   handleBirthSliderChange,
   handleDeathSliderChange,
   handleRankFilter,
-  handleUnknwonBirthYear,
-  handleUnknwonDeathYear,
+  handleUnknownBirthYear,
+  handleUnknownDeathYear,
 }: Props) {
   const t = useTranslations("roll");
 
@@ -92,7 +92,7 @@ export function RollFilter({
       </div>
       <div className={STYLES.filters}>
         <h3>{t("corps")}</h3>
-        {uniquecorps.map((corps) => (
+        {uniqueCorps.map((corps) => (
           <div key={String(corps.id)}>
             <label>
               <input
@@ -149,7 +149,7 @@ export function RollFilter({
               name={"unknownBirthYear"}
               value={"unknownBirthYear"}
               onChange={() =>
-                handleUnknwonBirthYear(
+                handleUnknownBirthYear(
                   filters.unknownBirthYear === "unknown" ? "" : "unknown",
                 )
               }
@@ -196,7 +196,7 @@ export function RollFilter({
               name={"unknownDeathYear"}
               value={"unknownDeathYear"}
               onChange={() =>
-                handleUnknwonDeathYear(
+                handleUnknownDeathYear(
                   filters.unknownDeathYear === "unknown" ? "" : "unknown",
                 )
               }

--- a/components/Roll/hooks/useRollState.ts
+++ b/components/Roll/hooks/useRollState.ts
@@ -1,0 +1,447 @@
+"use client";
+
+import isEqual from "lodash/isEqual";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Tunneller } from "@/types/tunnellers";
+import {
+  type FilterLookups,
+  type Filters,
+  type RollSortOrder,
+  filtersToSearchParams,
+  searchParamsToFilters,
+} from "@/utils/helpers/rollParams";
+
+import { getUniqueCorps, getUniqueCorpsEn } from "../utils/corpsUtils";
+import {
+  getUniqueDetachments,
+  getUniqueDetachmentsEn,
+} from "../utils/detachmentUtils";
+import {
+  getSortedRanks,
+  getUniqueRanks,
+  getUniqueRanksEn,
+} from "../utils/rankUtils";
+import { getUniqueBirthYears, getUniqueDeathYears } from "../utils/yearsUtils";
+
+type Params = {
+  tunnellers: Record<string, Tunneller[]>;
+  locale: string;
+};
+
+export function useRollState({ tunnellers, locale }: Params) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const isFirstRenderRef = useRef(true);
+  const previousSearchParamsRef = useRef(searchParams.toString());
+
+  const tunnellersList = useMemo(
+    () => Object.entries(tunnellers),
+    [tunnellers],
+  );
+  const uniqueDetachments = useMemo(
+    () => getUniqueDetachments(tunnellersList),
+    [tunnellersList],
+  );
+  const uniqueCorps = useMemo(
+    () => getUniqueCorps(tunnellersList),
+    [tunnellersList],
+  );
+  const uniqueRanks = useMemo(
+    () => getUniqueRanks(tunnellersList),
+    [tunnellersList],
+  );
+  const sortedRanks = useMemo(
+    () => getSortedRanks(uniqueRanks, locale as "en" | "fr"),
+    [uniqueRanks, locale],
+  );
+  const uniqueBirthYears = useMemo(
+    () => getUniqueBirthYears(tunnellersList),
+    [tunnellersList],
+  );
+  const uniqueDeathYears = useMemo(
+    () => getUniqueDeathYears(tunnellersList),
+    [tunnellersList],
+  );
+  const uniqueDetachmentsEn = useMemo(
+    () => getUniqueDetachmentsEn(tunnellersList),
+    [tunnellersList],
+  );
+  const uniqueCorpsEn = useMemo(
+    () => getUniqueCorpsEn(tunnellersList),
+    [tunnellersList],
+  );
+  const uniqueRanksEn = useMemo(
+    () => getUniqueRanksEn(tunnellersList),
+    [tunnellersList],
+  );
+  const sortedRanksEn = useMemo(
+    () => getSortedRanks(uniqueRanksEn, "en"),
+    [uniqueRanksEn],
+  );
+
+  const defaultFilters: Filters = useMemo(
+    () => ({
+      detachment: [],
+      corps: [],
+      ranks: {
+        Officers: [],
+        "Non-Commissioned Officers": [],
+        "Other Ranks": [],
+      },
+      birthYear: uniqueBirthYears,
+      unknownBirthYear: "unknown",
+      deathYear: uniqueDeathYears,
+      unknownDeathYear: "unknown",
+    }),
+    [uniqueBirthYears, uniqueDeathYears],
+  );
+
+  const filterLookups: FilterLookups = useMemo(
+    () => ({
+      detachments: uniqueDetachmentsEn,
+      corps: uniqueCorpsEn,
+      sortedRanks: sortedRanksEn,
+      birthYears: uniqueBirthYears,
+      deathYears: uniqueDeathYears,
+    }),
+    [
+      uniqueDetachmentsEn,
+      uniqueCorpsEn,
+      sortedRanksEn,
+      uniqueBirthYears,
+      uniqueDeathYears,
+    ],
+  );
+
+  const parsedUrlState = useMemo(
+    () => searchParamsToFilters(searchParams, filterLookups),
+    [searchParams, filterLookups],
+  );
+
+  const [filters, setFilters] = useState<Filters>(parsedUrlState.filters);
+  const [currentPage, setCurrentPage] = useState<number>(parsedUrlState.page);
+  const [sortOrder, setSortOrder] = useState<RollSortOrder>(
+    parsedUrlState.sortOrder,
+  );
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const searchParamsString = searchParams.toString();
+
+  useEffect(() => {
+    if (previousSearchParamsRef.current === searchParamsString) return;
+    previousSearchParamsRef.current = searchParamsString;
+    let cancelled = false;
+
+    queueMicrotask(() => {
+      if (cancelled) return;
+
+      if (!isEqual(filters, parsedUrlState.filters)) {
+        setFilters(parsedUrlState.filters);
+      }
+      if (currentPage !== parsedUrlState.page) {
+        setCurrentPage(parsedUrlState.page);
+      }
+      if (sortOrder !== parsedUrlState.sortOrder) {
+        setSortOrder(parsedUrlState.sortOrder);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParamsString, parsedUrlState, filters, currentPage, sortOrder]);
+
+  useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+    const qs = filtersToSearchParams(
+      filters,
+      currentPage,
+      sortOrder,
+      filterLookups,
+    );
+    const currentQs = window.location.search.replace(/^\?/, "");
+    if (qs === currentQs) return;
+    router.replace(`?${qs}`, { scroll: false });
+  }, [filters, currentPage, router, filterLookups, sortOrder]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const raw = localStorage.getItem("roll:scrollY");
+    const y = raw ? Number(raw) : 0;
+    if (Number.isFinite(y)) {
+      requestAnimationFrame(() => window.scrollTo(0, y));
+    }
+  }, []);
+
+  const hasAnyActiveFilter = useCallback((currentFilters: Filters): boolean => {
+    const ranksActive = Object.values(currentFilters.ranks ?? {}).some(
+      (arr) => arr.length,
+    );
+    const detachmentActive = (currentFilters.detachment ?? []).length > 0;
+    const corpsActive = (currentFilters.corps ?? []).length > 0;
+    const birthActive =
+      (currentFilters.birthYear ?? []).length > 0 ||
+      currentFilters.unknownBirthYear === "unknown";
+    const deathActive =
+      (currentFilters.deathYear ?? []).length > 0 ||
+      currentFilters.unknownDeathYear === "unknown";
+
+    return (
+      ranksActive ||
+      detachmentActive ||
+      corpsActive ||
+      birthActive ||
+      deathActive
+    );
+  }, []);
+
+  const activeFilterCount = [
+    Object.values(filters.ranks ?? {}).some((arr) => arr.length),
+    (filters.detachment ?? []).length > 0,
+    (filters.corps ?? []).length > 0,
+    (filters.birthYear ?? []).length < uniqueBirthYears.length ||
+      filters.unknownBirthYear === "",
+    (filters.deathYear ?? []).length < uniqueDeathYears.length ||
+      filters.unknownDeathYear === "",
+  ].filter(Boolean).length;
+
+  const filteredGroups: [string, Tunneller[]][] = useMemo(() => {
+    if (!hasAnyActiveFilter(filters)) return [];
+
+    return tunnellersList
+      .map<[string, Tunneller[]]>(([group, list]) => [
+        group,
+        list
+          .filter(
+            (tunneller) =>
+              !filters.detachment?.length ||
+              filters.detachment.includes(tunneller.detachmentId),
+          )
+          .filter((tunneller) => {
+            if (!filters.corps?.length) return true;
+            return filters.corps.includes(tunneller.corpsId);
+          })
+          .filter((tunneller) => {
+            const currentRanks = filters.ranks;
+            if (
+              !currentRanks ||
+              Object.values(currentRanks).every((arr) => arr.length === 0)
+            ) {
+              return true;
+            }
+            return Object.values(currentRanks).some((arr) =>
+              arr.includes(tunneller.rankId),
+            );
+          })
+          .filter((tunneller) => {
+            const wantsUnknown = filters.unknownBirthYear === "unknown";
+            const list = filters.birthYear ?? [];
+            if (wantsUnknown && tunneller.birthYear === null) return true;
+            if (list.length && tunneller.birthYear) {
+              return list.includes(tunneller.birthYear);
+            }
+            return !wantsUnknown && list.length === 0;
+          })
+          .filter((tunneller) => {
+            const wantsUnknown = filters.unknownDeathYear === "unknown";
+            const list = filters.deathYear ?? [];
+            if (wantsUnknown && tunneller.deathYear === null) return true;
+            if (list.length && tunneller.deathYear) {
+              return list.includes(tunneller.deathYear);
+            }
+            return !wantsUnknown && list.length === 0;
+          }),
+      ])
+      .filter(([, list]) => list.length > 0);
+  }, [filters, tunnellersList, hasAnyActiveFilter]);
+
+  const totalFilteredTunnellers = useMemo(
+    () => filteredGroups.reduce((acc, [, list]) => acc + list.length, 0),
+    [filteredGroups],
+  );
+
+  const sortedFilteredGroups = useMemo<[string, Tunneller[]][]>(() => {
+    const direction = sortOrder === "asc" ? 1 : -1;
+
+    return [...filteredGroups]
+      .sort(([groupA], [groupB]) => groupA.localeCompare(groupB) * direction)
+      .map<[string, Tunneller[]]>(([group, list]) => [
+        group,
+        [...list].sort((a, b) => {
+          const surnameCompare =
+            a.name.surname.localeCompare(b.name.surname) * direction;
+          if (surnameCompare !== 0) return surnameCompare;
+          return a.name.forename.localeCompare(b.name.forename) * direction;
+        }),
+      ]);
+  }, [filteredGroups, sortOrder]);
+
+  const totalTunnellers = useMemo(
+    () => tunnellersList.reduce((acc, [, list]) => acc + list.length, 0),
+    [tunnellersList],
+  );
+
+  const startBirthYear = filters.birthYear?.[0];
+  const endBirthYear = filters.birthYear?.[filters.birthYear.length - 1];
+  const startDeathYear = filters.deathYear?.[0];
+  const endDeathYear = filters.deathYear?.[filters.deathYear.length - 1];
+
+  const setPageToFirst = useCallback(() => setCurrentPage(1), []);
+
+  const handleDetachmentFilter = useCallback(
+    (detachmentId: number | null) => {
+      setFilters((prev) => {
+        const detachmentSet = new Set(prev.detachment ?? []);
+        detachmentSet.has(detachmentId)
+          ? detachmentSet.delete(detachmentId)
+          : detachmentSet.add(detachmentId);
+        return { ...prev, detachment: Array.from(detachmentSet) };
+      });
+      setPageToFirst();
+    },
+    [setPageToFirst],
+  );
+
+  const handleCorpsFilter = useCallback(
+    (corpsId: number | null) => {
+      setFilters((prev) => {
+        const corpsSet = new Set(prev.corps ?? []);
+        corpsSet.has(corpsId)
+          ? corpsSet.delete(corpsId)
+          : corpsSet.add(corpsId);
+        return { ...prev, corps: Array.from(corpsSet) };
+      });
+      setPageToFirst();
+    },
+    [setPageToFirst],
+  );
+
+  const handleBirthSliderChange = useCallback(
+    (value: number | number[]) => {
+      if (!Array.isArray(value)) return;
+      const [start, end] = value;
+      setFilters((prev) => ({
+        ...prev,
+        birthYear: uniqueBirthYears.filter(
+          (year) => year >= String(start) && year <= String(end),
+        ),
+      }));
+      setPageToFirst();
+    },
+    [uniqueBirthYears, setPageToFirst],
+  );
+
+  const handleUnknownBirthYear = useCallback(
+    (unknown: string) => {
+      setFilters((prev) => ({
+        ...prev,
+        unknownBirthYear: unknown ? "unknown" : "",
+      }));
+      setPageToFirst();
+    },
+    [setPageToFirst],
+  );
+
+  const handleDeathSliderChange = useCallback(
+    (value: number | number[]) => {
+      if (!Array.isArray(value)) return;
+      const [start, end] = value;
+      setFilters((prev) => ({
+        ...prev,
+        deathYear: uniqueDeathYears.filter(
+          (year) => year >= String(start) && year <= String(end),
+        ),
+      }));
+      setPageToFirst();
+    },
+    [uniqueDeathYears, setPageToFirst],
+  );
+
+  const handleUnknownDeathYear = useCallback(
+    (unknown: string) => {
+      setFilters((prev) => ({
+        ...prev,
+        unknownDeathYear: unknown ? "unknown" : "",
+      }));
+      setPageToFirst();
+    },
+    [setPageToFirst],
+  );
+
+  const handleRankFilter = useCallback(
+    (ranksFilter: Record<string, (number | null)[]>) => {
+      setFilters((prev) => {
+        const nextRanks: Record<string, (number | null)[]> = { ...prev.ranks };
+        Object.entries(ranksFilter).forEach(([category, rankIds]) => {
+          const rankSet = new Set(nextRanks[category] ?? []);
+          const allSelected = rankIds.every((id) => rankSet.has(id));
+          if (allSelected) {
+            rankIds.forEach((id) => rankSet.delete(id));
+          } else {
+            rankIds.forEach((id) => rankSet.add(id));
+          }
+          nextRanks[category] = Array.from(rankSet);
+        });
+        return { ...prev, ranks: nextRanks };
+      });
+      setPageToFirst();
+    },
+    [setPageToFirst],
+  );
+
+  const handleResetFilters = useCallback(() => {
+    if (!isEqual(filters, defaultFilters)) {
+      setCurrentPage(1);
+      setFilters(defaultFilters);
+    }
+  }, [filters, defaultFilters]);
+
+  const closeDialog = useCallback(() => setIsDialogOpen(false), []);
+  const openDialog = useCallback(() => setIsDialogOpen(true), []);
+  const handleSortToggle = useCallback(() => {
+    setCurrentPage(1);
+    setSortOrder((current) => (current === "asc" ? "desc" : "asc"));
+  }, []);
+
+  const rollFiltersProps = {
+    uniqueDetachments,
+    uniqueCorps,
+    uniqueBirthYears,
+    uniqueDeathYears,
+    sortedRanks,
+    filters,
+    startBirthYear,
+    endBirthYear,
+    startDeathYear,
+    endDeathYear,
+    handleDetachmentFilter,
+    handleCorpsFilter,
+    handleBirthSliderChange,
+    handleDeathSliderChange,
+    handleRankFilter,
+    handleUnknownBirthYear,
+    handleUnknownDeathYear,
+  };
+
+  return {
+    filters,
+    currentPage,
+    setCurrentPage,
+    sortOrder,
+    isDialogOpen,
+    closeDialog,
+    openDialog,
+    handleSortToggle,
+    rollFiltersProps,
+    activeFilterCount,
+    filteredGroups,
+    sortedFilteredGroups,
+    totalFilteredTunnellers,
+    totalTunnellers,
+    handleResetFilters,
+  };
+}


### PR DESCRIPTION
## What prompted this change?

After the `WorksMap` and `MapControls` cleanups, `Roll.tsx` stood out as the next component still mixing several different responsibilities in one file:

- URL parsing and syncing
- filter defaults and lookup construction
- derived filtered and sorted result groups
- dialog state and filter handlers
- rendering

This PR extracts that state and behavior into a dedicated hook so the `Roll` component is easier to scan and change without altering the UI structure.

## Summary of changes

- Extract the `Roll` state, URL syncing, derived filter data, dialog state, and handlers into `components/Roll/hooks/useRollState.ts`.
- Simplify `components/Roll/Roll.tsx` so it focuses on locale/text concerns and layout rendering.
- Keep the existing render structure and behavior unchanged while moving the non-visual logic out of the component.
- Clean up a couple of naming inconsistencies uncovered during the refactor:
  - rename `handleUnknwonBirthYear` / `handleUnknwonDeathYear` to `handleUnknownBirthYear` / `handleUnknownDeathYear`
  - rename `uniquecorps` to `uniqueCorps` in `RollFilter` props
- Update the relevant `RollFilter` tests to match the naming cleanup.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
