### PR TITLE
[NZT-131] Refactor HowToCite

### DIFF
--- a/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
+++ b/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
@@ -186,21 +186,15 @@ exports[`Article matches the snapshot 1`] = `
         </button>
       </h3>
       <p>
-        Anthony Byledbal, 
+        Anthony Byledbal, “My Awesome Article Title”, 
+        <em>
+          New Zealand Tunnellers Website
+        </em>
+        , 2023 (2009), Accessed: 4 May 2023. 
         <span>
-          “My Awesome Article Title”
-        </span>
-        , New Zealand Tunnellers Website, 2023 (2009), Accessed: 4 May 2023. 
-        <span>
-          URL: www.
+          URL: 
           <wbr />
-          nztunnellers
-          <wbr />
-          .com/
-          <wbr />
-          history/
-          <wbr />
-          my-awesome-article
+          www.nztunnellers.com/history/my-awesome-article
         </span>
       </p>
     </div>

--- a/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
+++ b/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
@@ -93,22 +93,15 @@ exports[`Chapter matches the snapshot 1`] = `
         </button>
       </h3>
       <p>
-        Anthony Byledbal, 
+        Anthony Byledbal, « Chapitre 1 : Les tunneliers des antipodes », in 
+        <em>
+          Les Kiwis aussi creusent des tunnels
+        </em>
+        , New Zealand Tunnellers Website, 2025 (2009), Consulté le : 1 janvier 2025. 
         <span>
-          « Chapitre 1  : Les tunneliers des antipodes », in 
-          <em>
-            Les Kiwis aussi creusent des tunnels
-          </em>
-        </span>
-        , New Zealand Tunnellers Website, 2025 (2009), Consulté le: 1 janvier 2025. 
-        <span>
-          URL:
+          URL : 
           <wbr />
-          www.nztunnellers
-          <wbr />
-          .com
-          <wbr />
-          /fr/books/kiwis-dig-tunnels-too/chapitre-1-les-tunneliers-des-antipodes
+          www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapitre-1-les-tunneliers-des-antipodes
         </span>
       </p>
     </div>

--- a/__tests__/unit/components/HowToCite/HowToCite.test.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+
+import { HowToCite } from "@/components/HowToCite/HowToCite";
+
+describe("HowToCite", () => {
+  test("italicizes the site title for regular page citations", () => {
+    const { container } = render(
+      <HowToCite title="Beneath Artois Fields" locale="en" />,
+    );
+
+    const emphasized = Array.from(container.querySelectorAll("em")).map(
+      (element) => element.textContent,
+    );
+
+    expect(emphasized).toContain("New Zealand Tunnellers Website");
+  });
+
+  test("italicizes the book title instead of the site title for book citations", () => {
+    const { container } = render(
+      <HowToCite
+        chapterTitle="Prologue"
+        pathname="/book/chapter-0-prologue"
+        locale="en"
+      />,
+    );
+
+    const emphasized = Array.from(container.querySelectorAll("em")).map(
+      (element) => element.textContent,
+    );
+
+    expect(emphasized).toContain("Kiwis Dig Tunnels Too");
+    expect(emphasized).not.toContain("New Zealand Tunnellers Website");
+    expect(container.querySelector("p")).toHaveTextContent(
+      "New Zealand Tunnellers Website",
+    );
+  });
+});

--- a/__tests__/unit/components/HowToCite/utils/citationFormatters.test.ts
+++ b/__tests__/unit/components/HowToCite/utils/citationFormatters.test.ts
@@ -1,0 +1,69 @@
+import {
+  buildCitationTitle,
+  buildCitationUrl,
+  formatBookSubpath,
+} from "@/components/HowToCite/utils/citationFormatters";
+
+describe("citationFormatters", () => {
+  test("formats an English chapter path into a citation title", () => {
+    expect(
+      buildCitationTitle({
+        pathname: "/book/chapter-4-tunnelling-under-arras",
+        locale: "en",
+      }),
+    ).toBe("“Chapter 4: Tunnelling under arras”, in Kiwis Dig Tunnels Too");
+  });
+
+  test("formats a French chapter path into a citation title", () => {
+    expect(
+      buildCitationTitle({
+        pathname: "/fr/livre/chapitre-4-tunnelling-under-arras",
+        locale: "fr",
+      }),
+    ).toBe(
+      "« Chapitre 4 : Tunnelling under arras », in Les Kiwis aussi creusent des tunnels",
+    );
+  });
+
+  test("builds a timeline citation title for a tunneller", () => {
+    expect(
+      buildCitationTitle({
+        summary: {
+          name: {
+            forename: "John",
+            surname: "Doe",
+          },
+          birth: "1886",
+          death: "1952",
+        },
+        timeline: true,
+        locale: "en",
+      }),
+    ).toBe("“World War I Timeline of John Doe”");
+  });
+
+  test("builds a history article URL from a title", () => {
+    expect(
+      buildCitationUrl({
+        title: "Beneath Artois Fields",
+        locale: "en",
+      }),
+    ).toBe("www.nztunnellers.com/history/beneath-artois-fields");
+  });
+
+  test("builds a timeline URL for a French tunneller page", () => {
+    expect(
+      buildCitationUrl({
+        tunnellerSlug: "john-doe",
+        timeline: true,
+        locale: "fr",
+      }),
+    ).toBe("www.nztunnellers.com/fr/tunnellers/john-doe/wwi-timeline");
+  });
+
+  test("formats a chapter path fragment", () => {
+    expect(
+      formatBookSubpath("/book/chapter-12-bridging-at-the-end", "en"),
+    ).toBe("Chapter 12: Bridging at the end");
+  });
+});

--- a/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
+++ b/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
@@ -349,17 +349,15 @@ exports[`Profile matches the snapshot 1`] = `
           </button>
         </h3>
         <p>
-          “John Smith (1886-1966)”, New Zealand Tunnellers Website, 2023 (2009), Accessed: 4 May 2023. 
+          “John Smith (1886-1966)”, 
+          <em>
+            New Zealand Tunnellers Website
+          </em>
+          , 2023 (2009), Accessed: 4 May 2023. 
           <span>
-            URL: www.
+            URL: 
             <wbr />
-            nztunnellers
-            <wbr />
-            .com/
-            <wbr />
-            tunnellers/
-            <wbr />
-            harry-corrin--4_1415
+            www.nztunnellers.com/tunnellers/harry-corrin--4_1415
           </span>
         </p>
       </div>

--- a/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
@@ -454,21 +454,15 @@ exports[`Timeline matches the snapshot 1`] = `
         </button>
       </h3>
       <p>
-        “World War I Timeline of John Smith”, New Zealand Tunnellers Website, 2023 (2009), Accessed: 4 May 2023. 
+        “World War I Timeline of John Smith”, 
+        <em>
+          New Zealand Tunnellers Website
+        </em>
+        , 2023 (2009), Accessed: 4 May 2023. 
         <span>
-          URL: www.
+          URL: 
           <wbr />
-          nztunnellers
-          <wbr />
-          .com/
-          <wbr />
-          tunnellers/
-          <wbr />
-          harry-corrin--4_1415/
-          <wbr />
-          wwi-
-          <wbr />
-          timeline
+          www.nztunnellers.com/tunnellers/harry-corrin--4_1415/wwi-timeline
         </span>
       </p>
     </div>

--- a/components/HowToCite/HowToCite.tsx
+++ b/components/HowToCite/HowToCite.tsx
@@ -6,9 +6,15 @@ import { useMemo, useRef } from "react";
 
 import type { Summary } from "@/types/tunneller";
 import { bookTitle } from "@/utils/helpers/books/basePathUtil";
-import { displayBiographyDates } from "@/utils/helpers/roll";
 
 import STYLES from "./HowToCite.module.scss";
+import {
+  buildCitationTitle,
+  buildCitationUrl,
+  formatCitationDate,
+  formatBookSubpath,
+  formatCitationYear,
+} from "./utils/citationFormatters";
 
 type Props = {
   tunnellerSlug?: string;
@@ -30,15 +36,6 @@ type HowToCiteUrlProps = {
   locale?: string;
 };
 
-type HowToCiteTitleProps = {
-  tunneller?: Summary;
-  title?: string;
-  chapterTitle?: string;
-  timeline?: boolean;
-  pathname?: string;
-  locale?: string;
-};
-
 export function HowToCiteUrl({
   tunnellerSlug,
   title,
@@ -47,156 +44,31 @@ export function HowToCiteUrl({
   pathname,
   locale = "en",
 }: HowToCiteUrlProps) {
-  const localePrefix = locale === "en" ? "" : `/${locale}`;
+  const fullUrl = buildCitationUrl({
+    tunnellerSlug,
+    title,
+    slug,
+    timeline,
+    pathname,
+    locale,
+  });
+  const urlLabel = locale === "fr" ? "URL\u00A0: " : "URL: ";
 
   if (pathname) {
     return (
       <span>
-        URL:
+        {urlLabel}
         <wbr />
-        www.nztunnellers
-        <wbr />
-        .com
-        <wbr />
-        {pathname}
+        {fullUrl}
       </span>
     );
   }
 
   return (
     <span>
-      URL: www.
+      {urlLabel}
       <wbr />
-      nztunnellers
-      <wbr />
-      .com{localePrefix}/
-      <wbr />
-      {tunnellerSlug && !timeline && (
-        <>
-          tunnellers/
-          <wbr />
-          {tunnellerSlug}
-        </>
-      )}
-      {tunnellerSlug && timeline && (
-        <>
-          tunnellers/
-          <wbr />
-          {tunnellerSlug}
-          /
-          <wbr />
-          wwi-
-          <wbr />
-          timeline
-        </>
-      )}
-      {!tunnellerSlug && (slug ?? title) && (
-        <>
-          history/
-          <wbr />
-          {slug ??
-            title
-              ?.replace(/\s+|\\/g, "-")
-              .replace(/&/g, "and")
-              .toLowerCase()}
-        </>
-      )}
-    </span>
-  );
-}
-
-function sentenceCase(str: string): string {
-  const lower = str.toLowerCase();
-  return lower.charAt(0).toUpperCase() + lower.slice(1);
-}
-
-function formatBookSubpath(pathname: string, locale: string): string {
-  const cleanPath = pathname.replace(/\/$/, "");
-  const segments = cleanPath.split("/");
-  const lastSegment = segments[segments.length - 1];
-
-  if (!lastSegment) return "";
-
-  const chapitreOrChapter = locale === "en" ? "chapter" : "chapitre";
-
-  const chapterMatch = lastSegment.match(
-    new RegExp(`^${chapitreOrChapter}-(\\d+)(?:-(.*))?$`, "i"),
-  );
-
-  const chapterWord = locale === "en" ? "Chapter" : "Chapitre";
-  const colon = locale === "en" ? ":" : "\u00A0:";
-
-  if (chapterMatch) {
-    const chapterNumber = chapterMatch[1];
-    const rest = chapterMatch[2];
-
-    if (!rest) {
-      return `${chapterWord} ${chapterNumber}${colon}`;
-    }
-
-    const formattedTitle = sentenceCase(rest.replace(/-/g, " "));
-    return `${chapterWord} ${chapterNumber}${colon} ${formattedTitle}`;
-  }
-
-  return sentenceCase(lastSegment.replace(/-/g, " "));
-}
-
-function HowToCiteTitle({
-  tunneller,
-  title,
-  chapterTitle,
-  timeline,
-  pathname,
-  locale,
-}: HowToCiteTitleProps) {
-  const openQuote = locale === "en" ? "\u201C" : "«\u00A0";
-  const closeQuote = locale === "en" ? "\u201D" : "\u00A0»";
-
-  if (pathname && locale) {
-    const rawTitle = chapterTitle ?? formatBookSubpath(pathname, locale);
-    const displayTitle =
-      locale === "fr" ? rawTitle.replace(/: /g, "\u00A0: ") : rawTitle;
-    return (
-      <span>
-        {openQuote}
-        {displayTitle}
-        {closeQuote}, in <em>{bookTitle(locale)}</em>
-      </span>
-    );
-  }
-
-  if (tunneller && !timeline) {
-    return (
-      <>
-        {openQuote}
-        {`${tunneller.name.forename} ${tunneller.name.surname} `}
-        {`(${displayBiographyDates(tunneller.birth, tunneller.death)})`}
-        {closeQuote}
-      </>
-    );
-  }
-
-  if (tunneller && timeline) {
-    const timelineOf =
-      locale === "en"
-        ? "World War I Timeline of"
-        : "Chronologie de la guerre de";
-    return (
-      <>
-        {openQuote}
-        {timelineOf}
-        {` ${tunneller.name.forename} ${tunneller.name.surname}`}
-        {closeQuote}
-      </>
-    );
-  }
-
-  const articleTitle = title?.replace(/\\/g, " ");
-  return (
-    <span>
-      {openQuote}
-      {articleTitle}
-      {closeQuote}
+      {fullUrl}
     </span>
   );
 }
@@ -221,24 +93,32 @@ export function HowToCite({
     [],
   );
   const currentDate = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale === "en" ? "en-GB" : "fr-FR", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-        timeZone: userTimeZone,
-      }).format(now),
+    () => formatCitationDate(now, locale, userTimeZone),
     [locale, now, userTimeZone],
   );
   const currentYear = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale === "en" ? "en-GB" : "fr-FR", {
-        year: "numeric",
-        timeZone: userTimeZone,
-      }).format(now),
+    () => formatCitationYear(now, locale, userTimeZone),
     [locale, now, userTimeZone],
   );
+  const accessedLabel = locale === "en" ? "Accessed: " : "Consulté le\u00A0: ";
   const citationAuthorPrefix = summary ? "" : "Anthony Byledbal, ";
+  const citationTitle = useMemo(
+    () =>
+      buildCitationTitle({
+        summary,
+        title,
+        chapterTitle,
+        timeline,
+        pathname,
+        locale,
+      }),
+    [summary, title, chapterTitle, timeline, pathname, locale],
+  );
+  const citationChapterTitle = useMemo(
+    () =>
+      pathname ? (chapterTitle ?? formatBookSubpath(pathname, locale)) : null,
+    [chapterTitle, pathname, locale],
+  );
 
   const handleCopy = () => {
     if (citationRef.current) {
@@ -286,16 +166,23 @@ export function HowToCite({
       </h3>
       <p ref={citationRef}>
         {citationAuthorPrefix}
-        <HowToCiteTitle
-          tunneller={summary}
-          title={title}
-          chapterTitle={chapterTitle}
-          timeline={timeline}
-          pathname={pathname}
-          locale={locale}
-        />
-        , New Zealand Tunnellers Website
-        {`, ${currentYear} (2009), ${locale === "en" ? "Accessed" : "Consulté le"}: `}
+        {citationChapterTitle ? (
+          <>
+            {locale === "en" ? "\u201C" : "«\u00A0"}
+            {citationChapterTitle}
+            {locale === "en" ? "\u201D" : "\u00A0»"}, in{" "}
+            <em>{bookTitle(locale)}</em>
+          </>
+        ) : (
+          citationTitle
+        )}
+        ,{" "}
+        {citationChapterTitle ? (
+          "New Zealand Tunnellers Website"
+        ) : (
+          <em>New Zealand Tunnellers Website</em>
+        )}
+        {`, ${currentYear} (2009), ${accessedLabel}`}
         {currentDate}
         {". "}
         <HowToCiteUrl

--- a/components/HowToCite/utils/citationFormatters.ts
+++ b/components/HowToCite/utils/citationFormatters.ts
@@ -1,0 +1,148 @@
+import type { Summary } from "@/types/tunneller";
+import { bookTitle } from "@/utils/helpers/books/basePathUtil";
+import { displayBiographyDates } from "@/utils/helpers/roll";
+
+type CitationTitleParams = {
+  summary?: Summary;
+  title?: string;
+  chapterTitle?: string;
+  timeline?: boolean;
+  pathname?: string;
+  locale: string;
+};
+
+type CitationUrlParams = {
+  tunnellerSlug?: string;
+  title?: string;
+  slug?: string;
+  timeline?: boolean;
+  pathname?: string;
+  locale?: string;
+};
+
+export function sentenceCase(str: string): string {
+  const lower = str.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+export function formatBookSubpath(pathname: string, locale: string): string {
+  const cleanPath = pathname.replace(/\/$/, "");
+  const segments = cleanPath.split("/");
+  const lastSegment = segments[segments.length - 1];
+
+  if (!lastSegment) return "";
+
+  const chapitreOrChapter = locale === "en" ? "chapter" : "chapitre";
+
+  const chapterMatch = lastSegment.match(
+    new RegExp(`^${chapitreOrChapter}-(\\d+)(?:-(.*))?$`, "i"),
+  );
+
+  const chapterWord = locale === "en" ? "Chapter" : "Chapitre";
+  const colon = locale === "en" ? ":" : "\u00A0:";
+
+  if (chapterMatch) {
+    const chapterNumber = chapterMatch[1];
+    const rest = chapterMatch[2];
+
+    if (!rest) {
+      return `${chapterWord} ${chapterNumber}${colon}`;
+    }
+
+    const formattedTitle = sentenceCase(rest.replace(/-/g, " "));
+    return `${chapterWord} ${chapterNumber}${colon} ${formattedTitle}`;
+  }
+
+  return sentenceCase(lastSegment.replace(/-/g, " "));
+}
+
+export function buildCitationTitle({
+  summary,
+  title,
+  chapterTitle,
+  timeline,
+  pathname,
+  locale,
+}: CitationTitleParams): string {
+  const openQuote = locale === "en" ? "\u201C" : "«\u00A0";
+  const closeQuote = locale === "en" ? "\u201D" : "\u00A0»";
+
+  if (pathname) {
+    const displayTitle = chapterTitle ?? formatBookSubpath(pathname, locale);
+    return `${openQuote}${displayTitle}${closeQuote}, in ${bookTitle(locale)}`;
+  }
+
+  if (summary && !timeline) {
+    return `${openQuote}${summary.name.forename} ${summary.name.surname} (${displayBiographyDates(summary.birth, summary.death)})${closeQuote}`;
+  }
+
+  if (summary && timeline) {
+    const timelineOf =
+      locale === "en"
+        ? "World War I Timeline of"
+        : "Chronologie de la guerre de";
+    return `${openQuote}${timelineOf} ${summary.name.forename} ${summary.name.surname}${closeQuote}`;
+  }
+
+  const articleTitle = title?.replace(/\\/g, " ") ?? "";
+  return `${openQuote}${articleTitle}${closeQuote}`;
+}
+
+export function buildCitationUrl({
+  tunnellerSlug,
+  title,
+  slug,
+  timeline,
+  pathname,
+  locale = "en",
+}: CitationUrlParams): string {
+  if (pathname) {
+    return `www.nztunnellers.com${pathname}`;
+  }
+
+  const localePrefix = locale === "en" ? "" : `/${locale}`;
+  const historySlug =
+    slug ??
+    title
+      ?.replace(/\s+|\\/g, "-")
+      .replace(/&/g, "and")
+      .toLowerCase();
+
+  if (tunnellerSlug && timeline) {
+    return `www.nztunnellers.com${localePrefix}/tunnellers/${tunnellerSlug}/wwi-timeline`;
+  }
+
+  if (tunnellerSlug) {
+    return `www.nztunnellers.com${localePrefix}/tunnellers/${tunnellerSlug}`;
+  }
+
+  if (historySlug) {
+    return `www.nztunnellers.com${localePrefix}/history/${historySlug}`;
+  }
+
+  return `www.nztunnellers.com${localePrefix}/`;
+}
+
+export function formatCitationDate(
+  now: Date,
+  locale: string,
+  timeZone: string,
+) {
+  return new Intl.DateTimeFormat(locale === "en" ? "en-NZ" : "fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone,
+  }).format(now);
+}
+
+export function formatCitationYear(
+  now: Date,
+  locale: string,
+  timeZone: string,
+) {
+  return new Intl.DateTimeFormat(locale === "en" ? "en-NZ" : "fr-FR", {
+    year: "numeric",
+    timeZone,
+  }).format(now);
+}


### PR DESCRIPTION
## What prompted this change?

`HowToCite.tsx` was still carrying a mix of responsibilities in one component:

- citation title and URL formatting
- locale-specific date and punctuation handling
- emphasis rules for book vs site titles
- clipboard behaviour and rendering

This PR takes the low-risk cleanup path by extracting the pure citation-formatting logic into a dedicated formatter module, while keeping the component-side clipboard and rendering flow in place.

## Summary of changes

- Extract pure citation formatting into `components/HowToCite/utils/citationFormatters.ts`, including:
  - `buildCitationTitle`
  - `buildCitationUrl`
  - `formatBookSubpath`
  - `formatCitationDate`
  - `formatCitationYear`
- Simplify `components/HowToCite/HowToCite.tsx` so it delegates string-building and date formatting instead of carrying that logic inline.
- Restore and clarify emphasis behaviour in citations:
  - book/chapter citations italicize the book title
  - other citations italicize `New Zealand Tunnellers Website`
- Fix locale-specific citation details:
  - use `en-NZ` rather than `en-GB` for English citation dates
  - use French inseparable spacing before colons for `Consulté le` and `URL`
  - restore the missing space after `URL:` in the rendered citation
- Add focused unit tests for both the pure citation formatters and the `HowToCite` emphasis behaviour.
- Update snapshots affected by the rendered citation output.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
