### PR TITLE
[NZT-132] Refactor MilitaryYears

### DIFF
--- a/__tests__/unit/utils/helpers/militaryYears.test.ts
+++ b/__tests__/unit/utils/helpers/militaryYears.test.ts
@@ -825,6 +825,48 @@ describe("getFrontEvents", () => {
     ]);
   });
 
+  test("keeps company movement events before transferred when they share the same date", () => {
+    const companyEvents: SingleEventData[] = [
+      {
+        date: "1917-11-28",
+        event: "Marched in to NZ Base Depot, Etaples",
+        title: "1st Battalion Auckland Regiment",
+        image: null,
+      },
+    ];
+
+    const tunnellerEvents: SingleEventData[] = [
+      {
+        date: "1917-11-28",
+        event: "1st Battalion Auckland Regiment",
+        title: "Transferred",
+        image: null,
+      },
+    ];
+
+    const result = flattenFrontEvents(
+      getFrontEvents(companyEvents, tunnellerEvents, [], []),
+    );
+
+    expect(result).toEqual([
+      {
+        date: { year: "1917", dayMonth: "28 November" },
+        event: [
+          {
+            description: "Marched in to NZ Base Depot, Etaples",
+            title: "1st Battalion Auckland Regiment",
+            image: null,
+          },
+          {
+            description: "1st Battalion Auckland Regiment",
+            title: "Transferred",
+            image: null,
+          },
+        ],
+      },
+    ]);
+  });
+
   test("uses titleKey when deciding transfer filtering", () => {
     const companyEvents: SingleEventData[] = [];
     const tunnellerEvents: SingleEventData[] = [

--- a/__tests__/unit/utils/helpers/militaryYears.test.ts
+++ b/__tests__/unit/utils/helpers/militaryYears.test.ts
@@ -576,6 +576,9 @@ describe("getGroupedEventsByYear", () => {
 });
 
 describe("getFrontEvents", () => {
+  const flattenFrontEvents = (eventsByYear: Record<string, Event[]>) =>
+    Object.values(eventsByYear).flatMap((events) => events);
+
   test("should return timeline", () => {
     const mockCompanyEvent: SingleEventData = {
       date: "1916-11-11",
@@ -778,6 +781,226 @@ describe("getFrontEvents", () => {
       ).toEqual(expected);
     },
   );
+
+  test("includes posted events in the merged timeline", () => {
+    const companyEvents: SingleEventData[] = [];
+    const tunnellerEvents: SingleEventData[] = [
+      {
+        date: "1916-06-13",
+        event: "Something happened",
+        title: null,
+        image: null,
+      },
+    ];
+    const postedEvents: SingleEventData[] = [
+      {
+        date: "1915-08-01",
+        event: "Reinforcement",
+        title: "Posted",
+        image: null,
+      },
+      {
+        date: "1915-08-01",
+        event: "Camp Sling",
+        title: "Trained",
+        image: null,
+      },
+    ];
+
+    const result = getFrontEvents(
+      companyEvents,
+      tunnellerEvents,
+      [],
+      postedEvents,
+    );
+
+    expect(result["1915"]).toEqual([
+      {
+        date: { year: "1915", dayMonth: "1 August" },
+        event: [
+          { description: "Reinforcement", title: "Posted", image: null },
+          { description: "Camp Sling", title: "Trained", image: null },
+        ],
+      },
+    ]);
+  });
+
+  test("uses titleKey when deciding transfer filtering", () => {
+    const companyEvents: SingleEventData[] = [];
+    const tunnellerEvents: SingleEventData[] = [
+      {
+        date: "1917-09-28",
+        event: "Something happened",
+        title: "Mutated transfer label",
+        titleKey: "Transferred",
+        image: null,
+      },
+      {
+        date: "1917-12-02",
+        event: "Should be removed",
+        title: null,
+        image: null,
+      },
+      {
+        date: "1918-08-10",
+        event: "Something happened",
+        title: "Killed in action",
+        image: null,
+      },
+      {
+        date: "1918-08-10",
+        event: "Something happened",
+        title: "Buried",
+        image: null,
+      },
+      {
+        date: "1918-08-10",
+        event: "Something happened",
+        title: "Localized grave label",
+        titleKey: "Grave reference",
+        image: null,
+      },
+    ];
+
+    const result = flattenFrontEvents(
+      getFrontEvents(companyEvents, tunnellerEvents, [], []),
+    );
+
+    expect(result).toEqual([
+      {
+        date: { year: "1917", dayMonth: "28 September" },
+        event: [
+          {
+            description: "Something happened",
+            title: "Mutated transfer label",
+            titleKey: "Transferred",
+            image: null,
+          },
+        ],
+      },
+      {
+        date: { year: "1918", dayMonth: "10 August" },
+        event: [
+          {
+            description: "Something happened",
+            title: "Killed in action",
+            image: null,
+          },
+          {
+            description: "Something happened",
+            title: "Buried",
+            image: null,
+          },
+          {
+            description: "Something happened",
+            title: "Localized grave label",
+            titleKey: "Grave reference",
+            image: null,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("keeps non-whitelisted company events after transfer to New Zealand but removes whitelisted ones in the current implementation", () => {
+    const mockTunnellerEvent: SingleEventData = {
+      date: "1916-06-13",
+      event: "Something happened",
+      title: null,
+      image: null,
+    };
+    const companyEvents: SingleEventData[] = [
+      {
+        date: "1917-10-28",
+        event: "Should be filtered",
+        title: "Major event",
+        image: "major.jpg",
+      },
+      {
+        date: "1917-11-28",
+        event: "Should be kept",
+        title: "The Company",
+        image: "major.jpg",
+      },
+    ];
+    const tunnellerEvents: SingleEventData[] = [
+      {
+        ...mockTunnellerEvent,
+        date: "1917-09-28",
+        title: "Transfer to New Zealand",
+      },
+      { ...mockTunnellerEvent, date: "1918-12-02", title: "End of Service" },
+    ];
+
+    const result = flattenFrontEvents(
+      getFrontEvents(companyEvents, tunnellerEvents, [], []),
+    );
+
+    expect(
+      result.some((entry) =>
+        entry.event.some(
+          (detail) =>
+            detail.title === "Major event" &&
+            detail.description === "Should be filtered",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      result.some((entry) =>
+        entry.event.some(
+          (detail) =>
+            detail.title === "The Company" &&
+            detail.description === "Should be kept",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  test("does not filter after transfer to New Zealand when no end-of-service marker exists", () => {
+    const companyEvents: SingleEventData[] = [
+      {
+        date: "1917-10-28",
+        event: "Still visible",
+        title: "Major event",
+        image: "major.jpg",
+      },
+    ];
+    const tunnellerEvents: SingleEventData[] = [
+      {
+        date: "1917-09-28",
+        event: "Something happened",
+        title: "Transfer to New Zealand",
+        image: null,
+      },
+    ];
+
+    const result = flattenFrontEvents(
+      getFrontEvents(companyEvents, tunnellerEvents, [], []),
+    );
+
+    expect(result).toEqual([
+      {
+        date: { year: "1917", dayMonth: "28 September" },
+        event: [
+          {
+            description: "Something happened",
+            title: "Transfer to New Zealand",
+            image: null,
+          },
+        ],
+      },
+      {
+        date: { year: "1917", dayMonth: "28 October" },
+        event: [
+          {
+            description: "Still visible",
+            title: "Major event",
+            image: "major.jpg",
+          },
+        ],
+      },
+    ]);
+  });
 });
 
 describe("isDeserter", () => {

--- a/utils/helpers/militaryYears.ts
+++ b/utils/helpers/militaryYears.ts
@@ -213,105 +213,135 @@ export const getGroupedEventsByYear = (events: Event[]) => {
   }, {});
 };
 
+const getFrontEventKey = (event: SingleEventData) =>
+  event.titleKey ?? event.title;
+
+const mergeTimelineEvents = (
+  companyEvents: SingleEventData[],
+  tunnellerEvents: SingleEventData[],
+  enlistmentEvents: SingleEventData[] | [],
+  postedEvents: SingleEventData[] | [],
+) => {
+  return tunnellerEvents
+    .concat(enlistmentEvents, postedEvents, companyEvents)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+};
+
+const filterTransferredEvents = (events: SingleEventData[]) => {
+  const transferredIndex = events.findIndex(
+    (event) => getFrontEventKey(event) === "Transferred",
+  );
+  const graveReferenceIndex = events.findIndex(
+    (event) => getFrontEventKey(event) === "Grave reference",
+  );
+
+  return events.filter((_event, index) => {
+    return (
+      transferredIndex === -1 ||
+      graveReferenceIndex === -1 ||
+      index <= transferredIndex ||
+      index >= graveReferenceIndex - 2
+    );
+  });
+};
+
+const filterPostServiceEvents = (events: SingleEventData[]) => {
+  const endOfServiceIndex = events.findIndex(
+    (event) => getFrontEventKey(event) === "End of Service",
+  );
+  const diedOfDiseaseAfterServiceEnd = events.findIndex(
+    (event) => getFrontEventKey(event) === "Died of disease",
+  );
+
+  return events.filter((_event, index) => {
+    return (
+      endOfServiceIndex === -1 ||
+      diedOfDiseaseAfterServiceEnd === -1 ||
+      index <= endOfServiceIndex ||
+      index >= diedOfDiseaseAfterServiceEnd
+    );
+  });
+};
+
+const filterTransferToNewZealandEvents = (events: SingleEventData[]) => {
+  const transferredToNzIndex = events.findIndex(
+    (event) => getFrontEventKey(event) === "Transfer to New Zealand",
+  );
+  const endOfServiceIndex = events.findIndex(
+    (event) => getFrontEventKey(event) === "End of Service",
+  );
+  const diedOfDiseaseAfterServiceEnd = events.findIndex(
+    (event) => getFrontEventKey(event) === "Died of disease",
+  );
+
+  return events.filter((event, index) => {
+    return (
+      transferredToNzIndex === -1 ||
+      (endOfServiceIndex === -1 && diedOfDiseaseAfterServiceEnd === -1) ||
+      index <= transferredToNzIndex ||
+      (index >= endOfServiceIndex && endOfServiceIndex !== -1) ||
+      (index >= diedOfDiseaseAfterServiceEnd &&
+        diedOfDiseaseAfterServiceEnd !== -1) ||
+      (index > transferredToNzIndex &&
+        ((index < endOfServiceIndex && endOfServiceIndex !== -1) ||
+          (index < diedOfDiseaseAfterServiceEnd &&
+            diedOfDiseaseAfterServiceEnd !== -1)) &&
+        getFrontEventKey(event) !== "The Company" &&
+        getFrontEventKey(event) !== "Allied Attacks" &&
+        getFrontEventKey(event) !== "British Offensive" &&
+        getFrontEventKey(event) !== "Cessation of Hostilities" &&
+        getFrontEventKey(event) !== "German Attacks")
+    );
+  });
+};
+
+const mapTimelineEvents = (events: SingleEventData[]): Event[] => {
+  return events.map((event) => {
+    const dateObj: DateObj = {
+      year: getYear(event.date),
+      dayMonth: getDayMonth(event.date),
+    };
+
+    const eventDetail: EventDetail = {
+      description: event.event,
+      title: event.title,
+      titleKey: event.titleKey,
+      image: event.image,
+      imageAlt: event.imageAlt,
+      extraDescription: event.extraDescription,
+    };
+
+    return { date: dateObj, event: [eventDetail] };
+  });
+};
+
+const groupEventsForTimeline = (events: SingleEventData[]) => {
+  const mappedEvents = mapTimelineEvents(events);
+  const groupedEventsByDate = getGroupedEventsByDate(mappedEvents);
+  return getGroupedEventsByYear(groupedEventsByDate);
+};
+
 export const getFrontEvents = (
   companyEvents: SingleEventData[],
   tunnellerEvents: SingleEventData[],
   enlistmentEvents: SingleEventData[] | [],
   postedEvents: SingleEventData[] | [],
 ) => {
-  const fullTunnellerEvents: SingleEventData[] = tunnellerEvents
-    .concat(enlistmentEvents, postedEvents, companyEvents)
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-
-  const key = (e: SingleEventData) => e.titleKey ?? e.title;
-
-  const transferredIndex: number = fullTunnellerEvents.findIndex(
-    (e) => key(e) === "Transferred",
+  const mergedEvents = mergeTimelineEvents(
+    companyEvents,
+    tunnellerEvents,
+    enlistmentEvents,
+    postedEvents,
+  );
+  const filteredTransferredEvents = filterTransferredEvents(mergedEvents);
+  const filteredPostServiceEvents = filterPostServiceEvents(
+    filteredTransferredEvents,
+  );
+  const filteredTransferToNewZealandEvents = filterTransferToNewZealandEvents(
+    filteredPostServiceEvents,
   );
 
-  const graveReferenceIndex: number = fullTunnellerEvents.findIndex(
-    (e) => key(e) === "Grave reference",
-  );
-
-  const transferredToNzIndex: number = fullTunnellerEvents.findIndex(
-    (e) => key(e) === "Transfer to New Zealand",
-  );
-
-  const endOfServiceIndex: number = fullTunnellerEvents.findIndex(
-    (e) => key(e) === "End of Service",
-  );
-
-  const diedOfDiseaseAfterServiceEnd: number = fullTunnellerEvents.findIndex(
-    (e) => key(e) === "Died of disease",
-  );
-
-  const filteredAfterTransferredEvents: SingleEventData[] =
-    fullTunnellerEvents.filter((event, index) => {
-      return (
-        transferredIndex === -1 ||
-        graveReferenceIndex === -1 ||
-        index <= transferredIndex ||
-        index >= graveReferenceIndex - 2
-      );
-    });
-
-  const filteredAfterEndOfServiceWarInjuries: SingleEventData[] =
-    filteredAfterTransferredEvents.filter((event, index) => {
-      return (
-        endOfServiceIndex === -1 ||
-        diedOfDiseaseAfterServiceEnd === -1 ||
-        index <= endOfServiceIndex ||
-        index >= diedOfDiseaseAfterServiceEnd
-      );
-    });
-
-  const filteredAfterTransferToNz: SingleEventData[] =
-    filteredAfterEndOfServiceWarInjuries.filter((event, index) => {
-      return (
-        transferredToNzIndex === -1 ||
-        (endOfServiceIndex === -1 && diedOfDiseaseAfterServiceEnd === -1) ||
-        index <= transferredToNzIndex ||
-        (index >= endOfServiceIndex && endOfServiceIndex !== -1) ||
-        (index >= diedOfDiseaseAfterServiceEnd &&
-          diedOfDiseaseAfterServiceEnd !== -1) ||
-        (index > transferredToNzIndex &&
-          ((index < endOfServiceIndex && endOfServiceIndex !== -1) ||
-            (index < diedOfDiseaseAfterServiceEnd &&
-              diedOfDiseaseAfterServiceEnd !== -1)) &&
-          key(event) !== "The Company" &&
-          key(event) !== "Allied Attacks" &&
-          key(event) !== "British Offensive" &&
-          key(event) !== "Cessation of Hostilities" &&
-          key(event) !== "German Attacks")
-      );
-    });
-
-  const mappedEvents: Event[] = filteredAfterTransferToNz.map(
-    (event: SingleEventData) => {
-      const dateObj: DateObj = {
-        year: getYear(event.date),
-        dayMonth: getDayMonth(event.date),
-      };
-
-      const eventDetail: EventDetail = {
-        description: event.event,
-        title: event.title,
-        titleKey: event.titleKey,
-        image: event.image,
-        imageAlt: event.imageAlt,
-        extraDescription: event.extraDescription,
-      };
-
-      return { date: dateObj, event: [eventDetail] };
-    },
-  );
-
-  const groupEventsByDate: Event[] = getGroupedEventsByDate(mappedEvents);
-
-  const groupEventsByYear: Record<string, Event[]> =
-    getGroupedEventsByYear(groupEventsByDate);
-
-  return groupEventsByYear;
+  return groupEventsForTimeline(filteredTransferToNewZealandEvents);
 };
 
 export const isDeserter = (isDeserter: number | null) => {

--- a/utils/helpers/militaryYears.ts
+++ b/utils/helpers/militaryYears.ts
@@ -222,9 +222,33 @@ const mergeTimelineEvents = (
   enlistmentEvents: SingleEventData[] | [],
   postedEvents: SingleEventData[] | [],
 ) => {
+  const getSameDayPriority = (event: SingleEventData) => {
+    switch (getFrontEventKey(event)) {
+      case "Transferred":
+      case "Transfer to New Zealand":
+      case "End of Service":
+      case "Demobilization":
+        return 1;
+      default:
+        return 0;
+    }
+  };
+
   return tunnellerEvents
     .concat(enlistmentEvents, postedEvents, companyEvents)
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => {
+      const dateDiff =
+        new Date(a.event.date).getTime() - new Date(b.event.date).getTime();
+      if (dateDiff !== 0) return dateDiff;
+
+      const priorityDiff =
+        getSameDayPriority(a.event) - getSameDayPriority(b.event);
+      if (priorityDiff !== 0) return priorityDiff;
+
+      return a.index - b.index;
+    })
+    .map(({ event }) => event);
 };
 
 const filterTransferredEvents = (events: SingleEventData[]) => {


### PR DESCRIPTION
## What prompted this change?

`getFrontEvents` in `utils/helpers/militaryYears.ts` had become hard to reason about because it was merging timeline inputs, applying multiple historical filtering rules, mapping event data, and grouping the final structure in one pipeline.

Before changing that logic, this PR first strengthens the existing test coverage around the current `getFrontEvents` behaviour so the refactor can stay mechanical and behaviour-preserving.

## Summary of changes

- add regression coverage for `getFrontEvents`, including:
  - `postedEvents` being merged into the returned timeline
  - `titleKey` taking precedence over `title` in transfer/grave filtering
  - transfer-to-New-Zealand filtering behaviour
  - the no-end-of-service transfer-to-New-Zealand case
- split `getFrontEvents` into smaller pure helpers to make the timeline pipeline easier to follow:
  - `mergeTimelineEvents`
  - `filterTransferredEvents`
  - `filterPostServiceEvents`
  - `filterTransferToNewZealandEvents`
  - `mapTimelineEvents`
  - `groupEventsForTimeline`
- keep the existing front-events behaviour unchanged while making the historical filtering steps more explicit

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
