### PR TITLE
[NZT-133] Slider date bug

### DIFF
--- a/__tests__/unit/components/Roll/RollFilter/RollFilter.test.tsx
+++ b/__tests__/unit/components/Roll/RollFilter/RollFilter.test.tsx
@@ -49,6 +49,8 @@ const defaultProps = {
   handleCorpsFilter: jest.fn(),
   handleBirthSliderChange: jest.fn(),
   handleDeathSliderChange: jest.fn(),
+  handleSliderDragStart: jest.fn(),
+  handleSliderDragComplete: jest.fn(),
   handleRankFilter: jest.fn(),
   handleUnknownBirthYear: jest.fn(),
   handleUnknownDeathYear: jest.fn(),

--- a/__tests__/unit/components/Roll/hooks/useRollState.test.tsx
+++ b/__tests__/unit/components/Roll/hooks/useRollState.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { useRollState } from "@/components/Roll/hooks/useRollState";
+import { mockTunnellers } from "@/test-utils/mocks/mockTunnellers";
+
+const mockReplace = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+function RollStateHarness() {
+  const { rollFiltersProps } = useRollState({
+    tunnellers: mockTunnellers,
+    locale: "en",
+  });
+
+  return (
+    <div>
+      <button onClick={rollFiltersProps.handleSliderDragStart}>
+        start drag
+      </button>
+      <button
+        onClick={() => rollFiltersProps.handleBirthSliderChange([1886, 1886])}
+      >
+        change birth years
+      </button>
+      <button onClick={rollFiltersProps.handleSliderDragComplete}>
+        complete drag
+      </button>
+      <div data-testid="birth-range">
+        {rollFiltersProps.startBirthYear}-{rollFiltersProps.endBirthYear}
+      </div>
+    </div>
+  );
+}
+
+describe("useRollState", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  test("does not sync the URL while a year slider drag is in progress", async () => {
+    render(<RollStateHarness />);
+
+    fireEvent.click(screen.getByText("start drag"));
+    fireEvent.click(screen.getByText("change birth years"));
+
+    expect(screen.getByTestId("birth-range")).toHaveTextContent("1886-1886");
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("complete drag"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/components/Roll/RollFilter/RollFilter.tsx
+++ b/components/Roll/RollFilter/RollFilter.tsx
@@ -38,6 +38,8 @@ type Props = {
   handleCorpsFilter: (corpsId: number | null) => void;
   handleBirthSliderChange: (value: number | number[]) => void;
   handleDeathSliderChange: (value: number | number[]) => void;
+  handleSliderDragStart: () => void;
+  handleSliderDragComplete: () => void;
   handleRankFilter: (rank: { [key: string]: (number | null)[] }) => void;
   handleUnknownBirthYear: (unknownBirthYear: string) => void;
   handleUnknownDeathYear: (unknownDeathYear: string) => void;
@@ -59,6 +61,8 @@ export function RollFilter({
   handleCorpsFilter,
   handleBirthSliderChange,
   handleDeathSliderChange,
+  handleSliderDragStart,
+  handleSliderDragComplete,
   handleRankFilter,
   handleUnknownBirthYear,
   handleUnknownDeathYear,
@@ -126,7 +130,9 @@ export function RollFilter({
             min={Number(uniqueBirthYears[0])}
             max={Number(uniqueBirthYears[uniqueBirthYears.length - 1])}
             value={[Number(startBirthYear), Number(endBirthYear)]}
+            onBeforeChange={handleSliderDragStart}
             onChange={handleBirthSliderChange}
+            onChangeComplete={handleSliderDragComplete}
             allowCross={false}
             ariaLabelForHandle={[t("birthYearStart"), t("birthYearEnd")]}
             styles={{
@@ -173,7 +179,9 @@ export function RollFilter({
             min={Number(uniqueDeathYears[0])}
             max={Number(uniqueDeathYears[uniqueDeathYears.length - 1])}
             value={[Number(startDeathYear), Number(endDeathYear)]}
+            onBeforeChange={handleSliderDragStart}
             onChange={handleDeathSliderChange}
+            onChangeComplete={handleSliderDragComplete}
             allowCross={false}
             ariaLabelForHandle={[t("deathYearStart"), t("deathYearEnd")]}
             styles={{

--- a/components/Roll/hooks/useRollState.ts
+++ b/components/Roll/hooks/useRollState.ts
@@ -126,6 +126,7 @@ export function useRollState({ tunnellers, locale }: Params) {
     parsedUrlState.sortOrder,
   );
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isSliderDragging, setIsSliderDragging] = useState(false);
   const searchParamsString = searchParams.toString();
 
   useEffect(() => {
@@ -157,6 +158,7 @@ export function useRollState({ tunnellers, locale }: Params) {
       isFirstRenderRef.current = false;
       return;
     }
+    if (isSliderDragging) return;
     const qs = filtersToSearchParams(
       filters,
       currentPage,
@@ -166,7 +168,14 @@ export function useRollState({ tunnellers, locale }: Params) {
     const currentQs = window.location.search.replace(/^\?/, "");
     if (qs === currentQs) return;
     router.replace(`?${qs}`, { scroll: false });
-  }, [filters, currentPage, router, filterLookups, sortOrder]);
+  }, [
+    filters,
+    currentPage,
+    router,
+    filterLookups,
+    sortOrder,
+    isSliderDragging,
+  ]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -402,6 +411,14 @@ export function useRollState({ tunnellers, locale }: Params) {
 
   const closeDialog = useCallback(() => setIsDialogOpen(false), []);
   const openDialog = useCallback(() => setIsDialogOpen(true), []);
+  const handleSliderDragStart = useCallback(
+    () => setIsSliderDragging(true),
+    [],
+  );
+  const handleSliderDragComplete = useCallback(
+    () => setIsSliderDragging(false),
+    [],
+  );
   const handleSortToggle = useCallback(() => {
     setCurrentPage(1);
     setSortOrder((current) => (current === "asc" ? "desc" : "asc"));
@@ -422,6 +439,8 @@ export function useRollState({ tunnellers, locale }: Params) {
     handleCorpsFilter,
     handleBirthSliderChange,
     handleDeathSliderChange,
+    handleSliderDragStart,
+    handleSliderDragComplete,
     handleRankFilter,
     handleUnknownBirthYear,
     handleUnknownDeathYear,


### PR DESCRIPTION
## What prompted this change?

The birth/death year sliders on the roll page could become stuck in production while dragging. The filter state was updating on every slider movement, and the URL was being synced at the same time, which could trigger a route update mid-drag and interrupt the interaction.

## Summary of changes

- defer roll URL syncing while a birth/death year slider drag is in progress
- add explicit slider drag start/complete handlers to `RollFilter` using the `rc-slider` lifecycle callbacks
- update `useRollState` so `router.replace` only resumes once dragging has completed
- add a focused regression test proving filter state can change during a drag without syncing the URL until the drag ends

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
