### PR TITLE
[NZT-134] Fix breadcrumb hydration warning

### DIFF
--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -11,6 +11,7 @@ import { ProfileSummary } from "@/components/Profile/ProfileSummary/ProfileSumma
 import { Title } from "@/components/Title/Title";
 import { TunnellerProfile } from "@/types/tunneller";
 import { displayBiographyDates } from "@/utils/helpers/roll";
+import { useStoredReturnUrl } from "@/utils/helpers/useStoredReturnUrl";
 
 import STYLES from "./Profile.module.scss";
 
@@ -22,12 +23,7 @@ export function Profile({ tunneller }: Props) {
   const t = useTranslations("profile");
   const locale = useLocale();
   const localePrefix = locale === "en" ? "" : `/${locale}`;
-
-  const returnUrl =
-    typeof window !== "undefined"
-      ? (localStorage.getItem("tunnellers:return") ??
-        `${localePrefix}/tunnellers`)
-      : `${localePrefix}/tunnellers`;
+  const returnUrl = useStoredReturnUrl(`${localePrefix}/tunnellers`);
 
   return (
     <>

--- a/components/Timeline/Timeline.tsx
+++ b/components/Timeline/Timeline.tsx
@@ -7,6 +7,7 @@ import { HowToCite } from "@/components/HowToCite/HowToCite";
 import { TimelineEvents } from "@/components/Timeline/TimelineEvents/TimelineEvents";
 import { Title } from "@/components/Title/Title";
 import { TunnellerProfile } from "@/types/tunneller";
+import { useStoredReturnUrl } from "@/utils/helpers/useStoredReturnUrl";
 
 import STYLES from "./Timeline.module.scss";
 
@@ -18,12 +19,7 @@ export function Timeline({ tunneller }: Props) {
   const t = useTranslations("timeline");
   const locale = useLocale();
   const localePrefix = locale === "en" ? "" : `/${locale}`;
-
-  const returnUrl =
-    typeof window !== "undefined"
-      ? (localStorage.getItem("tunnellers:return") ??
-        `${localePrefix}/tunnellers`)
-      : `${localePrefix}/tunnellers`;
+  const returnUrl = useStoredReturnUrl(`${localePrefix}/tunnellers`);
 
   return (
     <div className={STYLES.timeline}>

--- a/utils/helpers/useStoredReturnUrl.ts
+++ b/utils/helpers/useStoredReturnUrl.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribeToNothing = () => () => {};
+
+export function useStoredReturnUrl(fallbackUrl: string) {
+  return useSyncExternalStore(
+    subscribeToNothing,
+    () => localStorage.getItem("tunnellers:return") ?? fallbackUrl,
+    () => fallbackUrl,
+  );
+}


### PR DESCRIPTION
## What prompted this change?

A hydration warning was being triggered on the timeline/profile breadcrumb link because the `returnUrl` was being computed during render with a server/client branch. The server rendered the fallback `/tunnellers` URL, while the client could immediately render a different `localStorage` value such as a fully-qualified local URL, causing the `href` to mismatch during hydration.

## Summary of changes

- add a small `useStoredReturnUrl` helper based on `useSyncExternalStore`
- update `Timeline` to use the shared helper instead of reading `localStorage` directly in render
- update `Profile` to use the same shared helper for the breadcrumb link
- keep the server snapshot stable by always using the fallback URL during SSR, then reading the stored return URL safely on the client

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
