### PR TITLE
[NZT-135] Refactor timeline event translations to use title and description keys

### DIFF
--- a/__tests__/unit/components/Timeline/TimelineEvent.test.tsx
+++ b/__tests__/unit/components/Timeline/TimelineEvent.test.tsx
@@ -202,3 +202,84 @@ describe("TimelineEvent with buried and grave reference", () => {
     expect(screen.getByText("1 A 26")).toBeInTheDocument();
   });
 });
+
+describe("TimelineEvent with translated helper-generated labels", () => {
+  test("renders transferred and transfer labels from titleKey", () => {
+    render(
+      <TimelineEvent
+        event={[
+          {
+            description: "1st Battalion Auckland Regiment",
+            title: null,
+            titleKey: "Transferred",
+            image: null,
+          },
+          {
+            description: "HMNZT 300 Ulimaroa",
+            title: null,
+            titleKey: "Transfer to New Zealand",
+            image: null,
+          },
+          {
+            description: "HMNZT 100 Athenic",
+            title: null,
+            titleKey: "Transfer to England",
+            image: null,
+          },
+        ]}
+        ageAtEnlistment={null}
+      />,
+    );
+
+    expect(screen.getByText("Transferred")).toBeInTheDocument();
+    expect(
+      screen.getByText("1st Battalion Auckland Regiment"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Transfer to New Zealand")).toBeInTheDocument();
+    expect(screen.getByText("HMNZT 300 Ulimaroa")).toBeInTheDocument();
+    expect(screen.getByText("Transfer to England")).toBeInTheDocument();
+    expect(screen.getByText("HMNZT 100 Athenic")).toBeInTheDocument();
+  });
+
+  test("renders UK discharge demobilization copy from descriptionKey", () => {
+    render(
+      <TimelineEvent
+        event={[
+          {
+            description: "",
+            descriptionKey: "endOfServiceUK",
+            title: null,
+            titleKey: "Demobilization",
+            image: null,
+          },
+        ]}
+        ageAtEnlistment={null}
+      />,
+    );
+
+    expect(screen.getByText("Demobilisation")).toBeInTheDocument();
+    expect(
+      screen.getByText("End of Service in the United Kingdom"),
+    ).toBeInTheDocument();
+  });
+
+  test("renders general demobilization copy from descriptionKey", () => {
+    render(
+      <TimelineEvent
+        event={[
+          {
+            description: "",
+            descriptionKey: "demobilization",
+            title: null,
+            titleKey: "End of Service",
+            image: null,
+          },
+        ]}
+        ageAtEnlistment={null}
+      />,
+    );
+
+    expect(screen.getByText("End of Service")).toBeInTheDocument();
+    expect(screen.getByText("Demobilisation")).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/utils/helpers/militaryYears.test.ts
+++ b/__tests__/unit/utils/helpers/militaryYears.test.ts
@@ -1129,8 +1129,9 @@ describe("getDemobilization", () => {
     const result = getDemobilization("2023-01-01", 1, null);
     expect(result).toEqual({
       date: "2023-01-01",
-      event: "End of Service in the United Kingdom",
-      title: "Demobilisation",
+      event: "",
+      descriptionKey: "endOfServiceUK",
+      title: null,
       titleKey: "Demobilization",
       image: null,
     });
@@ -1140,8 +1141,9 @@ describe("getDemobilization", () => {
     const result = getDemobilization("2023-01-01", null, 1);
     expect(result).toEqual({
       date: "2023-01-01",
-      event: "End of Service as deserter",
-      title: "Demobilisation",
+      event: "",
+      descriptionKey: "endOfServiceDeserter",
+      title: null,
       titleKey: "Demobilization",
       image: null,
     });
@@ -1151,8 +1153,9 @@ describe("getDemobilization", () => {
     const result = getDemobilization("2023-01-01", null, null);
     expect(result).toEqual({
       date: "2023-01-01",
-      event: "Demobilisation",
-      title: "End of Service",
+      event: "",
+      descriptionKey: "demobilization",
+      title: null,
       titleKey: "End of Service",
       image: null,
     });
@@ -1161,39 +1164,6 @@ describe("getDemobilization", () => {
   test("returns null when date is null", () => {
     const result = getDemobilization(null, null, null);
     expect(result).toBeNull();
-  });
-
-  test("returns French UK discharge event with fr locale", () => {
-    const result = getDemobilization("2023-01-01", 1, null, "fr");
-    expect(result).toEqual({
-      date: "2023-01-01",
-      event: "Fin de service au Royaume-Uni",
-      title: "Démobilisation",
-      titleKey: "Demobilization",
-      image: null,
-    });
-  });
-
-  test("returns French deserter event with fr locale", () => {
-    const result = getDemobilization("2023-01-01", null, 1, "fr");
-    expect(result).toEqual({
-      date: "2023-01-01",
-      event: "Fin de service en tant que déserteur",
-      title: "Démobilisation",
-      titleKey: "Demobilization",
-      image: null,
-    });
-  });
-
-  test("returns French general demobilization event with fr locale", () => {
-    const result = getDemobilization("2023-01-01", null, null, "fr");
-    expect(result).toEqual({
-      date: "2023-01-01",
-      event: "Démobilisation",
-      title: "Fin de service",
-      titleKey: "End of Service",
-      image: null,
-    });
   });
 });
 

--- a/components/Timeline/TimelineEvent/TimelineEvent.tsx
+++ b/components/Timeline/TimelineEvent/TimelineEvent.tsx
@@ -16,11 +16,42 @@ type Props = {
 export function TimelineEvent({ event, ageAtEnlistment }: Props) {
   const t = useTranslations("timeline");
 
+  const getTranslatedTitle = (key: string, fallbackTitle: string | null) => {
+    switch (key) {
+      case "Enlisted":
+        return t("enlisted");
+      case "Posted":
+        return t("posted");
+      case "Trained":
+        return t("trained");
+      case "Buried":
+        return t("buried");
+      case "Grave reference":
+        return t("graveReference");
+      case "Demobilization":
+        return t("demobilization");
+      case "End of Service":
+        return t("endOfService");
+      case "Transfer to England":
+        return t("transferToEngland");
+      case "Transfer to New Zealand":
+        return t("transferToNewZealand");
+      case "Transferred":
+        return t("transferred");
+      default:
+        return fallbackTitle;
+    }
+  };
+
   return (
     <>
       {event.map((eventDetail: EventDetail) => {
-        const { title } = eventDetail;
-        const key = eventDetail.titleKey ?? title;
+        const { title, titleKey, description, descriptionKey } = eventDetail;
+        const key = titleKey ?? title;
+        const displayTitle = key ? getTranslatedTitle(key, title) : null;
+        const displayDescription = descriptionKey
+          ? t(descriptionKey)
+          : description;
 
         const isTitleCompany = key === "The Company";
         const isTitleEnlisted = key === "Enlisted";
@@ -46,7 +77,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
           return translatedTitle;
         };
 
-        if (title) {
+        if (key) {
           if (isTitleCompany) {
             return (
               <div key={event.indexOf(eventDetail)}>
@@ -65,7 +96,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                     className={STYLES["event-image"]}
                     placeholder="empty"
                   />
-                  <p>{renderSuperscript(eventDetail.description)}</p>
+                  <p>{renderSuperscript(displayDescription)}</p>
                 </div>
               </div>
             );
@@ -77,8 +108,8 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                 key={event.indexOf(eventDetail)}
                 className={STYLES["main-event"]}
               >
-                <p>{titleWithAgeAtEnlistment(title, ageAtEnlistment)}</p>
-                <span>{renderSuperscript(eventDetail.description)}</span>
+                <p>{titleWithAgeAtEnlistment(key, ageAtEnlistment)}</p>
+                <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }
@@ -90,7 +121,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                 className={STYLES["tunneller-event-with-title"]}
               >
                 <p>{t("trained")}</p>
-                <span>{renderSuperscript(eventDetail.description)}</span>
+                <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }
@@ -106,14 +137,14 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                 key={event.indexOf(eventDetail)}
                 className={STYLES["main-event"]}
               >
-                <span>{title}</span>
+                <span>{displayTitle}</span>
                 {eventDetail.extraDescription ? (
                   <span
                     className={STYLES.info}
                   >{` (${eventDetail.extraDescription})`}</span>
                 ) : null}
                 <span className={STYLES["info-block-with-description"]}>
-                  {renderSuperscript(eventDetail.description)}
+                  {renderSuperscript(displayDescription)}
                 </span>
               </div>
             );
@@ -126,7 +157,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                 className={STYLES["tunneller-event-with-title"]}
               >
                 <p>{isTitleBuried ? t("buried") : t("graveReference")}</p>
-                <span>{renderSuperscript(eventDetail.description)}</span>
+                <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }
@@ -138,7 +169,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                 className={STYLES["main-event"]}
               >
                 <p>{t("demobilization")}</p>
-                <span>{renderSuperscript(eventDetail.description)}</span>
+                <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }
@@ -150,7 +181,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                 className={STYLES["main-event"]}
               >
                 <p>{t("endOfService")}</p>
-                <span>{renderSuperscript(eventDetail.description)}</span>
+                <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }
@@ -160,8 +191,8 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
               key={event.indexOf(eventDetail)}
               className={STYLES["main-event"]}
             >
-              <p>{title}</p>
-              <span>{renderSuperscript(eventDetail.description)}</span>
+              <p>{displayTitle}</p>
+              <span>{renderSuperscript(displayDescription)}</span>
             </div>
           );
         }
@@ -171,7 +202,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
             key={event.indexOf(eventDetail)}
             className={STYLES["tunneller-event"]}
           >
-            <p>{renderSuperscript(eventDetail.description)}</p>
+            <p>{renderSuperscript(displayDescription)}</p>
           </div>
         );
       })}

--- a/messages/en.json
+++ b/messages/en.json
@@ -162,6 +162,9 @@
     "endOfService": "End of Service",
     "endOfServiceUK": "End of Service in the United Kingdom",
     "endOfServiceDeserter": "End of Service as deserter",
+    "transferToEngland": "Transfer to England",
+    "transferToNewZealand": "Transfer to New Zealand",
+    "transferred": "Transferred",
     "enlistedAtAge": "{title} at the age of {age}",
     "companyEventAlt": "Image for {title}",
     "companyEventAltFallback": "Company event"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -162,6 +162,9 @@
     "endOfService": "Fin de service",
     "endOfServiceUK": "Fin de service au Royaume-Uni",
     "endOfServiceDeserter": "Fin de service en tant que déserteur",
+    "transferToEngland": "Transfert en Angleterre",
+    "transferToNewZealand": "Transfert en Nouvelle-Zélande",
+    "transferred": "Transféré",
     "enlistedAtAge": "{title} à l'âge de {age} ans",
     "companyEventAlt": "Image pour {title}",
     "companyEventAltFallback": "Événement de la compagnie"

--- a/types/tunneller.ts
+++ b/types/tunneller.ts
@@ -94,6 +94,7 @@ export type SingleEventData = {
   date: string;
   event: string;
   eventKey?: string | null;
+  descriptionKey?: string | null;
   title: string | null;
   titleKey?: string | null;
   image: string | null;
@@ -209,6 +210,7 @@ export type Transport = {
 
 export type EventDetail = {
   description: string;
+  descriptionKey?: string | null;
   title: string | null;
   titleKey?: string | null;
   image: string | null;

--- a/utils/database/getTunneller.ts
+++ b/utils/database/getTunneller.ts
@@ -101,8 +101,7 @@ export async function getTunneller(
     ? {
         date: profile.transport_uk_start,
         event: `${profile.transport_uk_ref} ${profile.transport_uk_vessel}`,
-        title:
-          locale === "en" ? "Transfer to England" : "Transfert en Angleterre",
+        title: null,
         titleKey: "Transfer to England",
         image: null,
       }
@@ -112,10 +111,7 @@ export async function getTunneller(
     ? {
         date: profile.transport_nz_start,
         event: `${profile.transport_nz_ref} ${profile.transport_nz_vessel}`,
-        title:
-          locale === "en"
-            ? "Transfer to New Zealand"
-            : "Transfert en Nouvelle-Zélande",
+        title: null,
         titleKey: "Transfer to New Zealand",
         image: null,
       }
@@ -126,7 +122,7 @@ export async function getTunneller(
       ? {
           date: profile.transferred_to_date,
           event: profile.transferred_to_unit,
-          title: locale === "en" ? "Transferred" : "Transféré",
+          title: null,
           titleKey: "Transferred",
           image: null,
         }
@@ -172,7 +168,6 @@ export async function getTunneller(
       profile.demobilization_date,
       profile.discharge_uk,
       profile.has_deserted,
-      locale,
     ),
   ]
     .concat(tunnellerEvents, getWarDeathEvents(death))

--- a/utils/helpers/militaryYears.ts
+++ b/utils/helpers/militaryYears.ts
@@ -328,6 +328,7 @@ const mapTimelineEvents = (events: SingleEventData[]): Event[] => {
 
     const eventDetail: EventDetail = {
       description: event.event,
+      descriptionKey: event.descriptionKey,
       title: event.title,
       titleKey: event.titleKey,
       image: event.image,
@@ -397,17 +398,13 @@ export const getDemobilization = (
   date: string | null,
   dischargeUk: number | null,
   deserted: number | null,
-  locale: string = "en",
 ) => {
-  const isEn = locale === "en";
-
   if (date && dischargeUk === 1) {
     return {
-      date: date,
-      event: isEn
-        ? "End of Service in the United Kingdom"
-        : "Fin de service au Royaume-Uni",
-      title: isEn ? "Demobilisation" : "Démobilisation",
+      date,
+      event: "",
+      descriptionKey: "endOfServiceUK",
+      title: null,
       titleKey: "Demobilization",
       image: null,
     };
@@ -415,11 +412,10 @@ export const getDemobilization = (
 
   if (date && deserted === 1) {
     return {
-      date: date,
-      event: isEn
-        ? "End of Service as deserter"
-        : "Fin de service en tant que déserteur",
-      title: isEn ? "Demobilisation" : "Démobilisation",
+      date,
+      event: "",
+      descriptionKey: "endOfServiceDeserter",
+      title: null,
       titleKey: "Demobilization",
       image: null,
     };
@@ -427,9 +423,10 @@ export const getDemobilization = (
 
   if (date) {
     return {
-      date: date,
-      event: isEn ? "Demobilisation" : "Démobilisation",
-      title: isEn ? "End of Service" : "Fin de service",
+      date,
+      event: "",
+      descriptionKey: "demobilization",
+      title: null,
       titleKey: "End of Service",
       image: null,
     };


### PR DESCRIPTION
  ## What prompted this change?

  NZT-135 refactors how timeline event copy is localized. Timeline labels and descriptions were being generated in helpers
  and the data layer with locale-specific strings, which made the translation logic inconsistent and harder to maintain.
  This change moves that responsibility into the TimelineEvent component so events are rendered from translation keys
  instead.

  ## Summary of changes

  - Refactored timeline event rendering to use titleKey and descriptionKey for translated labels and descriptions.
  - Removed locale-specific transfer and demobilization strings from getTunneller and getDemobilization.
  - Added missing English and French translation entries for transfer-related timeline copy.
  - Updated timeline event types to support descriptionKey.
  - Added and updated unit tests covering helper-generated translated timeline labels.

  ## Checklist

  - [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
  - [x] Unit and integration tests added or updated, and coverage is maintained or improved;
  - [ ] If appropriate, documentation created or updated.