### PR TITLE
[NZT-136] birth/death slider updates query params live while draging

### DIFF
--- a/__tests__/unit/components/Roll/hooks/useRollState.test.tsx
+++ b/__tests__/unit/components/Roll/hooks/useRollState.test.tsx
@@ -5,6 +5,7 @@ import { mockTunnellers } from "@/test-utils/mocks/mockTunnellers";
 
 const mockReplace = jest.fn();
 let mockSearchParams = new URLSearchParams();
+const originalReplaceState = window.history.replaceState.bind(window.history);
 
 jest.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
@@ -41,9 +42,14 @@ describe("useRollState", () => {
   beforeEach(() => {
     mockReplace.mockReset();
     mockSearchParams = new URLSearchParams();
+    window.scrollTo = jest.fn();
+    window.history.replaceState = jest.fn((data, unused, url) =>
+      originalReplaceState(data, unused, url),
+    );
+    originalReplaceState(null, "", "/");
   });
 
-  test("does not sync the URL while a year slider drag is in progress", async () => {
+  test("updates the URL with history state while a year slider drag is in progress", async () => {
     render(<RollStateHarness />);
 
     fireEvent.click(screen.getByText("start drag"));
@@ -51,11 +57,17 @@ describe("useRollState", () => {
 
     expect(screen.getByTestId("birth-range")).toHaveTextContent("1886-1886");
     expect(mockReplace).not.toHaveBeenCalled();
+    expect(window.history.replaceState).toHaveBeenCalledTimes(1);
+    expect(window.history.replaceState).toHaveBeenCalledWith(
+      null,
+      "",
+      expect.stringContaining("?birth-min=1886&birth-max=1886"),
+    );
 
     fireEvent.click(screen.getByText("complete drag"));
 
     await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledTimes(1);
+      expect(mockReplace).not.toHaveBeenCalled();
     });
   });
 });

--- a/components/Roll/hooks/useRollState.ts
+++ b/components/Roll/hooks/useRollState.ts
@@ -158,6 +158,23 @@ export function useRollState({ tunnellers, locale }: Params) {
       isFirstRenderRef.current = false;
       return;
     }
+    if (!isSliderDragging) return;
+    const qs = filtersToSearchParams(
+      filters,
+      currentPage,
+      sortOrder,
+      filterLookups,
+    );
+    const currentQs = window.location.search.replace(/^\?/, "");
+    if (qs === currentQs) return;
+    const url = qs
+      ? `${window.location.pathname}?${qs}`
+      : window.location.pathname;
+    window.history.replaceState(null, "", url);
+  }, [filters, currentPage, filterLookups, sortOrder, isSliderDragging]);
+
+  useEffect(() => {
+    if (isFirstRenderRef.current) return;
     if (isSliderDragging) return;
     const qs = filtersToSearchParams(
       filters,


### PR DESCRIPTION
 ## What prompted this change?

  The birth and death year sliders on the roll page stopped reflecting their state in the URL while dragging after the slider refactor. The works map slider still updates query
  params live, so the roll page behaviour had become inconsistent and made it harder to share or inspect the current filtered state while moving the slider.

  ## Summary of changes

  - updated the roll slider URL sync so birth and death year query params are written live during drag
  - used window.history.replaceState(...) for in-progress slider updates instead of routing on every drag step
  - kept the existing non-drag router sync path in place for the rest of the roll filter state
  - updated the useRollState unit test to cover live URL updates during slider drag

  ## Checklist

  - [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
  - [x] Unit and integration tests added or updated, and coverage is maintained or improved;
  - [ ] If appropriate, documentation created or updated.