### PR TITLE
[NZT-137] Fix bug for roll filters

### DIFF
--- a/__tests__/unit/components/Roll/Roll.test.tsx
+++ b/__tests__/unit/components/Roll/Roll.test.tsx
@@ -12,6 +12,7 @@ import { mockTunnellers } from "@/test-utils/mocks/mockTunnellers";
 
 const mockReplace = jest.fn();
 let mockSearchParams = new URLSearchParams();
+const originalReplaceState = window.history.replaceState.bind(window.history);
 
 jest.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
@@ -27,8 +28,13 @@ async function renderRoll() {
 describe("Roll", () => {
   beforeEach(() => {
     localStorage.clear();
+    mockReplace.mockReset();
     mockSearchParams = new URLSearchParams();
     window.scrollTo = jest.fn();
+    window.history.replaceState = jest.fn((data, unused, url) =>
+      originalReplaceState(data, unused, url),
+    );
+    originalReplaceState(null, "", "/");
   });
 
   test("matches the snapshot", async () => {
@@ -406,10 +412,14 @@ describe("Roll", () => {
     fireEvent.click(sortButtons[0]);
 
     await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith("?sort=desc", {
-        scroll: false,
-      });
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        null,
+        "",
+        expect.stringContaining("?sort=desc"),
+      );
     });
+
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 
   test("should filter Tunnelling Corps shows only tunnellers without attached corps", async () => {

--- a/__tests__/unit/components/Roll/hooks/useRollState.test.tsx
+++ b/__tests__/unit/components/Roll/hooks/useRollState.test.tsx
@@ -28,6 +28,9 @@ function RollStateHarness() {
       >
         change birth years
       </button>
+      <button onClick={() => rollFiltersProps.handleDetachmentFilter(1)}>
+        toggle detachment
+      </button>
       <button onClick={rollFiltersProps.handleSliderDragComplete}>
         complete drag
       </button>
@@ -69,5 +72,21 @@ describe("useRollState", () => {
     await waitFor(() => {
       expect(mockReplace).not.toHaveBeenCalled();
     });
+  });
+
+  test("updates the URL with history state when a non-slider filter is clicked", async () => {
+    render(<RollStateHarness />);
+
+    fireEvent.click(screen.getByText("toggle detachment"));
+
+    await waitFor(() => {
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        null,
+        "",
+        expect.stringContaining("?detachment=main-body"),
+      );
+    });
+
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 });

--- a/components/Roll/hooks/useRollState.ts
+++ b/components/Roll/hooks/useRollState.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import isEqual from "lodash/isEqual";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Tunneller } from "@/types/tunnellers";
@@ -32,7 +32,6 @@ type Params = {
 
 export function useRollState({ tunnellers, locale }: Params) {
   const searchParams = useSearchParams();
-  const router = useRouter();
   const isFirstRenderRef = useRef(true);
   const previousSearchParamsRef = useRef(searchParams.toString());
 
@@ -128,6 +127,14 @@ export function useRollState({ tunnellers, locale }: Params) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isSliderDragging, setIsSliderDragging] = useState(false);
   const searchParamsString = searchParams.toString();
+  const syncUrl = useCallback((qs: string) => {
+    const currentQs = window.location.search.replace(/^\?/, "");
+    if (qs === currentQs) return;
+    const url = qs
+      ? `${window.location.pathname}?${qs}`
+      : window.location.pathname;
+    window.history.replaceState(null, "", url);
+  }, []);
 
   useEffect(() => {
     if (previousSearchParamsRef.current === searchParamsString) return;
@@ -165,13 +172,15 @@ export function useRollState({ tunnellers, locale }: Params) {
       sortOrder,
       filterLookups,
     );
-    const currentQs = window.location.search.replace(/^\?/, "");
-    if (qs === currentQs) return;
-    const url = qs
-      ? `${window.location.pathname}?${qs}`
-      : window.location.pathname;
-    window.history.replaceState(null, "", url);
-  }, [filters, currentPage, filterLookups, sortOrder, isSliderDragging]);
+    syncUrl(qs);
+  }, [
+    filters,
+    currentPage,
+    filterLookups,
+    sortOrder,
+    isSliderDragging,
+    syncUrl,
+  ]);
 
   useEffect(() => {
     if (isFirstRenderRef.current) return;
@@ -182,16 +191,14 @@ export function useRollState({ tunnellers, locale }: Params) {
       sortOrder,
       filterLookups,
     );
-    const currentQs = window.location.search.replace(/^\?/, "");
-    if (qs === currentQs) return;
-    router.replace(`?${qs}`, { scroll: false });
+    syncUrl(qs);
   }, [
     filters,
     currentPage,
-    router,
     filterLookups,
     sortOrder,
     isSliderDragging,
+    syncUrl,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## What prompted this change?

The roll page had inconsistent URL sync behaviour after the birth/death slider refactor. In production, interacting with roll filters could trigger route-based URL updates that caused the page to jump to the top, while the works map already handled query param updates in place. This change aligns the roll page with the map approach so filter state stays reflected in the URL without route navigation side effects.

  ## Summary of changes

  - updated roll filter URL syncing to use window.history.replaceState(...) instead of router navigation
  - kept birth and death year query params updating live while dragging the sliders
  - fixed the roll filter interaction so clicking filters no longer triggers page scroll-to-top behaviour
  - updated roll unit tests to assert history-based URL updates for slider, sort, and filter interactions

  ## Checklist

  - [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
  - [x] Unit and integration tests added or updated, and coverage is maintained or improved;
  - [ ] If appropriate, documentation created or updated.