### PR TITLE
[NZT-138] Move getJoinEvents to fully semantic keys

### DIFF
--- a/__tests__/unit/utils/helpers/militaryYears.test.ts
+++ b/__tests__/unit/utils/helpers/militaryYears.test.ts
@@ -180,13 +180,15 @@ describe("getJoinEvents", () => {
         {
           date: "2020-01-01",
           event: "Unit A",
-          title: joinType,
+          title: null,
+          titleKey: joinType,
           image: null,
         },
         {
           date: "2020-02-01",
           event: "Location A",
-          title: "Trained",
+          title: null,
+          titleKey: "Trained",
           image: null,
         },
       ];
@@ -211,13 +213,15 @@ describe("getJoinEvents", () => {
         {
           date: "2020-02-01",
           event: "Unit B",
-          title: joinType,
+          title: null,
+          titleKey: joinType,
           image: null,
         },
         {
           date: "2020-02-01",
           event: "Location B",
-          title: "Trained",
+          title: null,
+          titleKey: "Trained",
           image: null,
         },
       ];
@@ -606,8 +610,18 @@ describe("getFrontEvents", () => {
     ];
 
     const mockEnlistment: SingleEventData[] = [
-      { ...mockTunnellerEvent, date: "1915-09-01", title: "Enlisted" },
-      { ...mockTunnellerEvent, date: "1915-10-10", title: "Trained" },
+      {
+        ...mockTunnellerEvent,
+        date: "1915-09-01",
+        title: null,
+        titleKey: "Enlisted",
+      },
+      {
+        ...mockTunnellerEvent,
+        date: "1915-10-10",
+        title: null,
+        titleKey: "Trained",
+      },
     ];
 
     expect(
@@ -653,8 +667,18 @@ describe("getFrontEvents", () => {
     ];
 
     const mockEnlistment: SingleEventData[] = [
-      { ...mockTunnellerEvent, date: "1915-09-01", title: "Enlisted" },
-      { ...mockTunnellerEvent, date: "1915-10-10", title: "Trained" },
+      {
+        ...mockTunnellerEvent,
+        date: "1915-09-01",
+        title: null,
+        titleKey: "Enlisted",
+      },
+      {
+        ...mockTunnellerEvent,
+        date: "1915-10-10",
+        title: null,
+        titleKey: "Trained",
+      },
     ];
 
     expect(
@@ -698,8 +722,18 @@ describe("getFrontEvents", () => {
     ];
 
     const mockEnlistment: SingleEventData[] = [
-      { ...mockTunnellerEvent, date: "1915-09-01", title: "Enlisted" },
-      { ...mockTunnellerEvent, date: "1915-10-10", title: "Trained" },
+      {
+        ...mockTunnellerEvent,
+        date: "1915-09-01",
+        title: null,
+        titleKey: "Enlisted",
+      },
+      {
+        ...mockTunnellerEvent,
+        date: "1915-10-10",
+        title: null,
+        titleKey: "Trained",
+      },
     ];
 
     expect(
@@ -767,8 +801,18 @@ describe("getFrontEvents", () => {
       ];
 
       const mockEnlistment: SingleEventData[] = [
-        { ...mockTunnellerEvent, date: "1915-09-01", title: "Enlisted" },
-        { ...mockTunnellerEvent, date: "1915-10-10", title: "Trained" },
+        {
+          ...mockTunnellerEvent,
+          date: "1915-09-01",
+          title: null,
+          titleKey: "Enlisted",
+        },
+        {
+          ...mockTunnellerEvent,
+          date: "1915-10-10",
+          title: null,
+          titleKey: "Trained",
+        },
       ];
 
       expect(
@@ -796,13 +840,15 @@ describe("getFrontEvents", () => {
       {
         date: "1915-08-01",
         event: "Reinforcement",
-        title: "Posted",
+        title: null,
+        titleKey: "Posted",
         image: null,
       },
       {
         date: "1915-08-01",
         event: "Camp Sling",
-        title: "Trained",
+        title: null,
+        titleKey: "Trained",
         image: null,
       },
     ];
@@ -818,8 +864,18 @@ describe("getFrontEvents", () => {
       {
         date: { year: "1915", dayMonth: "1 August" },
         event: [
-          { description: "Reinforcement", title: "Posted", image: null },
-          { description: "Camp Sling", title: "Trained", image: null },
+          {
+            description: "Reinforcement",
+            title: null,
+            titleKey: "Posted",
+            image: null,
+          },
+          {
+            description: "Camp Sling",
+            title: null,
+            titleKey: "Trained",
+            image: null,
+          },
         ],
       },
     ]);

--- a/test-utils/mocks/mockFrontEvents.ts
+++ b/test-utils/mocks/mockFrontEvents.ts
@@ -178,7 +178,8 @@ export const mockFrontEventsWithCompanyEvents = {
         {
           description: "Something happened",
           image: null,
-          title: "Enlisted",
+          title: null,
+          titleKey: "Enlisted",
         },
       ],
     },
@@ -191,7 +192,8 @@ export const mockFrontEventsWithCompanyEvents = {
         {
           description: "Something happened",
           image: null,
-          title: "Trained",
+          title: null,
+          titleKey: "Trained",
         },
       ],
     },

--- a/utils/helpers/militaryYears.ts
+++ b/utils/helpers/militaryYears.ts
@@ -47,13 +47,15 @@ export const getJoinEvents = (join: JoinEventData | null) => {
       {
         date: join.date,
         event: join.embarkationUnit,
-        title: join.isEnlisted ? "Enlisted" : "Posted",
+        title: null,
+        titleKey: join.isEnlisted ? "Enlisted" : "Posted",
         image: null,
       },
       {
         date: join.trainingStart,
         event: join.trainingLocation,
-        title: "Trained",
+        title: null,
+        titleKey: "Trained",
         image: null,
       },
     );
@@ -64,13 +66,15 @@ export const getJoinEvents = (join: JoinEventData | null) => {
       {
         date: join.date,
         event: join.embarkationUnit,
-        title: join.isEnlisted ? "Enlisted" : "Posted",
+        title: null,
+        titleKey: join.isEnlisted ? "Enlisted" : "Posted",
         image: null,
       },
       {
         date: join.date,
         event: join.trainingLocation,
-        title: "Trained",
+        title: null,
+        titleKey: "Trained",
         image: null,
       },
     );


### PR DESCRIPTION
## What prompted this change?

The timeline event refactor was only partially complete. Demobilization and transfer events had already moved to semantic titleKey and descriptionKey values, but join events were still emitting raw display strings such as Enlisted, Posted, and Trained from the helper layer. This change finishes that part of the refactor so timeline event localization stays consistently component-driven.

  ## Summary of changes

  - updated getJoinEvents to return semantic titleKey values for Enlisted, Posted, and Trained
  - removed remaining raw join-event titles from the helper output
  - kept translation/rendering logic in the timeline component
  - updated helper tests and shared timeline fixtures to assert key-based event data instead of display strings

  ## Checklist

  - [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
  - [x] Unit and integration tests added or updated, and coverage is maintained or improved;
  - [ ] If appropriate, documentation created or updated.