### PR TITLE
[NZT-140] Reduce manual title-key branching in TimelineEvent

### DIFF
--- a/__tests__/unit/components/Timeline/TimelineEvent.test.tsx
+++ b/__tests__/unit/components/Timeline/TimelineEvent.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { useTranslations } from "next-intl";
 
 import { TimelineEvent } from "@/components/Timeline/TimelineEvent/TimelineEvent";
 import {
@@ -15,6 +16,48 @@ import {
   mockEventTitleAndDescription,
   mockEventTrained,
 } from "@/test-utils/mocks/mockFrontEvents";
+
+beforeEach(() => {
+  (useTranslations as jest.Mock).mockImplementation((namespace: string) => {
+    if (namespace !== "timeline") {
+      return (key: string) => key;
+    }
+
+    return (key: string, values?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        enlisted: "Enlisted",
+        posted: "Posted",
+        trained: "Trained",
+        killedInAction: "Killed in action",
+        diedOfWounds: "Died of wounds",
+        diedOfDisease: "Died of disease",
+        diedOfAccident: "Died of accident",
+        buried: "Buried",
+        graveReference: "Grave reference",
+        demobilization: "Demobilisation",
+        endOfService: "End of Service",
+        endOfServiceUK: "End of Service in the United Kingdom",
+        transferToEngland: "Transfer to England",
+        transferToNewZealand: "Transfer to New Zealand",
+        transferred: "Transferred",
+        companyEventAlt: "Image for {title}",
+        companyEventAltFallback: "Company event",
+      };
+
+      if (key === "enlistedAtAge") {
+        return `${values?.title} at the age of ${values?.age}`;
+      }
+
+      const translation = translations[key];
+      if (!translation) return key;
+
+      if (!values) return translation;
+      return translation.replace(/\{(\w+)\}/g, (_match, token: string) =>
+        String(values[token] ?? `{${token}}`),
+      );
+    };
+  });
+});
 
 test("uses explicit imageAlt when provided for a Company event", () => {
   render(

--- a/components/Timeline/TimelineEvent/TimelineEvent.tsx
+++ b/components/Timeline/TimelineEvent/TimelineEvent.tsx
@@ -13,42 +13,46 @@ type Props = {
   ageAtEnlistment: number | null;
 };
 
+const TITLE_TRANSLATION_KEYS: Record<string, string> = {
+  Enlisted: "enlisted",
+  Posted: "posted",
+  Trained: "trained",
+  "Killed in action": "killedInAction",
+  "Died of wounds": "diedOfWounds",
+  "Died of disease": "diedOfDisease",
+  "Died of accident": "diedOfAccident",
+  Buried: "buried",
+  "Grave reference": "graveReference",
+  Demobilization: "demobilization",
+  "End of Service": "endOfService",
+  "Transfer to England": "transferToEngland",
+  "Transfer to New Zealand": "transferToNewZealand",
+  Transferred: "transferred",
+};
+
+const INLINE_INFO_TITLES = new Set([
+  "Killed in action",
+  "Died of wounds",
+  "Died of disease",
+  "Died of accident",
+]);
+
+const STACKED_TITLE_TITLES = new Set(["Trained", "Buried", "Grave reference"]);
+
 export function TimelineEvent({ event, ageAtEnlistment }: Props) {
   const t = useTranslations("timeline");
 
   const getTranslatedTitle = (key: string, fallbackTitle: string | null) => {
-    switch (key) {
-      case "Enlisted":
-        return t("enlisted");
-      case "Posted":
-        return t("posted");
-      case "Trained":
-        return t("trained");
-      case "Buried":
-        return t("buried");
-      case "Grave reference":
-        return t("graveReference");
-      case "Killed in action":
-        return t("killedInAction");
-      case "Died of wounds":
-        return t("diedOfWounds");
-      case "Died of disease":
-        return t("diedOfDisease");
-      case "Died of accident":
-        return t("diedOfAccident");
-      case "Demobilization":
-        return t("demobilization");
-      case "End of Service":
-        return t("endOfService");
-      case "Transfer to England":
-        return t("transferToEngland");
-      case "Transfer to New Zealand":
-        return t("transferToNewZealand");
-      case "Transferred":
-        return t("transferred");
-      default:
-        return fallbackTitle;
+    const translationKey = TITLE_TRANSLATION_KEYS[key];
+    return translationKey ? t(translationKey) : fallbackTitle;
+  };
+
+  const getTitleWithAgeAtEnlistment = (key: string, age: number | null) => {
+    const translatedTitle = key === "Enlisted" ? t("enlisted") : t("posted");
+    if (age) {
+      return t("enlistedAtAge", { title: translatedTitle, age });
     }
+    return translatedTitle;
   };
 
   return (
@@ -61,32 +65,8 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
           ? t(descriptionKey)
           : description;
 
-        const isTitleCompany = key === "The Company";
-        const isTitleEnlisted = key === "Enlisted";
-        const isTitlePosted = key === "Posted";
-        const isTitleTrained = key === "Trained";
-        const isTitleKilledInAction = key === "Killed in action";
-        const isTitleDiedOfWounds = key === "Died of wounds";
-        const isTitleDiedOfDisease = key === "Died of disease";
-        const isTitleDiedOfAccident = key === "Died of accident";
-        const isTitleBuried = key === "Buried";
-        const isTitleGraveReference = key === "Grave reference";
-        const isTitleDemobilization = key === "Demobilization";
-        const isTitleEndOfService = key === "End of Service";
-
-        const titleWithAgeAtEnlistment = (
-          title: string,
-          age: number | null,
-        ) => {
-          const translatedTitle = isTitleEnlisted ? t("enlisted") : t("posted");
-          if (age) {
-            return t("enlistedAtAge", { title: translatedTitle, age });
-          }
-          return translatedTitle;
-        };
-
         if (key) {
-          if (isTitleCompany) {
+          if (key === "The Company") {
             return (
               <div key={event.indexOf(eventDetail)}>
                 <div className={STYLES["company-event"]}>
@@ -110,36 +90,31 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
             );
           }
 
-          if (isTitleEnlisted || isTitlePosted) {
+          if (key === "Enlisted" || key === "Posted") {
             return (
               <div
                 key={event.indexOf(eventDetail)}
                 className={STYLES["main-event"]}
               >
-                <p>{titleWithAgeAtEnlistment(key, ageAtEnlistment)}</p>
+                <p>{getTitleWithAgeAtEnlistment(key, ageAtEnlistment)}</p>
                 <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }
 
-          if (isTitleTrained) {
+          if (STACKED_TITLE_TITLES.has(key)) {
             return (
               <div
                 key={event.indexOf(eventDetail)}
                 className={STYLES["tunneller-event-with-title"]}
               >
-                <p>{t("trained")}</p>
+                <p>{displayTitle}</p>
                 <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }
 
-          if (
-            isTitleKilledInAction ||
-            isTitleDiedOfWounds ||
-            isTitleDiedOfDisease ||
-            isTitleDiedOfAccident
-          ) {
+          if (INLINE_INFO_TITLES.has(key)) {
             return (
               <div
                 key={event.indexOf(eventDetail)}
@@ -154,42 +129,6 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
                 <span className={STYLES["info-block-with-description"]}>
                   {renderSuperscript(displayDescription)}
                 </span>
-              </div>
-            );
-          }
-
-          if (isTitleBuried || isTitleGraveReference) {
-            return (
-              <div
-                key={event.indexOf(eventDetail)}
-                className={STYLES["tunneller-event-with-title"]}
-              >
-                <p>{isTitleBuried ? t("buried") : t("graveReference")}</p>
-                <span>{renderSuperscript(displayDescription)}</span>
-              </div>
-            );
-          }
-
-          if (isTitleDemobilization) {
-            return (
-              <div
-                key={event.indexOf(eventDetail)}
-                className={STYLES["main-event"]}
-              >
-                <p>{t("demobilization")}</p>
-                <span>{renderSuperscript(displayDescription)}</span>
-              </div>
-            );
-          }
-
-          if (isTitleEndOfService) {
-            return (
-              <div
-                key={event.indexOf(eventDetail)}
-                className={STYLES["main-event"]}
-              >
-                <p>{t("endOfService")}</p>
-                <span>{renderSuperscript(displayDescription)}</span>
               </div>
             );
           }

--- a/components/Timeline/TimelineEvent/TimelineEvent.tsx
+++ b/components/Timeline/TimelineEvent/TimelineEvent.tsx
@@ -13,38 +13,53 @@ type Props = {
   ageAtEnlistment: number | null;
 };
 
-const TITLE_TRANSLATION_KEYS: Record<string, string> = {
-  Enlisted: "enlisted",
-  Posted: "posted",
-  Trained: "trained",
-  "Killed in action": "killedInAction",
-  "Died of wounds": "diedOfWounds",
-  "Died of disease": "diedOfDisease",
-  "Died of accident": "diedOfAccident",
-  Buried: "buried",
-  "Grave reference": "graveReference",
-  Demobilization: "demobilization",
-  "End of Service": "endOfService",
-  "Transfer to England": "transferToEngland",
-  "Transfer to New Zealand": "transferToNewZealand",
-  Transferred: "transferred",
+const TITLE_CONFIG: Record<
+  string,
+  {
+    translationKey: string;
+    variant: "default" | "enlistment" | "inlineInfo" | "stacked";
+  }
+> = {
+  Enlisted: { translationKey: "enlisted", variant: "enlistment" },
+  Posted: { translationKey: "posted", variant: "enlistment" },
+  Trained: { translationKey: "trained", variant: "stacked" },
+  "Killed in action": {
+    translationKey: "killedInAction",
+    variant: "inlineInfo",
+  },
+  "Died of wounds": {
+    translationKey: "diedOfWounds",
+    variant: "inlineInfo",
+  },
+  "Died of disease": {
+    translationKey: "diedOfDisease",
+    variant: "inlineInfo",
+  },
+  "Died of accident": {
+    translationKey: "diedOfAccident",
+    variant: "inlineInfo",
+  },
+  Buried: { translationKey: "buried", variant: "stacked" },
+  "Grave reference": { translationKey: "graveReference", variant: "stacked" },
+  Demobilization: { translationKey: "demobilization", variant: "default" },
+  "End of Service": { translationKey: "endOfService", variant: "default" },
+  "Transfer to England": {
+    translationKey: "transferToEngland",
+    variant: "default",
+  },
+  "Transfer to New Zealand": {
+    translationKey: "transferToNewZealand",
+    variant: "default",
+  },
+  Transferred: { translationKey: "transferred", variant: "default" },
 };
-
-const INLINE_INFO_TITLES = new Set([
-  "Killed in action",
-  "Died of wounds",
-  "Died of disease",
-  "Died of accident",
-]);
-
-const STACKED_TITLE_TITLES = new Set(["Trained", "Buried", "Grave reference"]);
 
 export function TimelineEvent({ event, ageAtEnlistment }: Props) {
   const t = useTranslations("timeline");
 
   const getTranslatedTitle = (key: string, fallbackTitle: string | null) => {
-    const translationKey = TITLE_TRANSLATION_KEYS[key];
-    return translationKey ? t(translationKey) : fallbackTitle;
+    const config = TITLE_CONFIG[key];
+    return config ? t(config.translationKey) : fallbackTitle;
   };
 
   const getTitleWithAgeAtEnlistment = (key: string, age: number | null) => {
@@ -60,6 +75,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
       {event.map((eventDetail: EventDetail) => {
         const { title, titleKey, description, descriptionKey } = eventDetail;
         const key = titleKey ?? title;
+        const titleConfig = key ? TITLE_CONFIG[key] : undefined;
         const displayTitle = key ? getTranslatedTitle(key, title) : null;
         const displayDescription = descriptionKey
           ? t(descriptionKey)
@@ -102,7 +118,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
             );
           }
 
-          if (STACKED_TITLE_TITLES.has(key)) {
+          if (titleConfig?.variant === "stacked") {
             return (
               <div
                 key={event.indexOf(eventDetail)}
@@ -114,7 +130,7 @@ export function TimelineEvent({ event, ageAtEnlistment }: Props) {
             );
           }
 
-          if (INLINE_INFO_TITLES.has(key)) {
+          if (titleConfig?.variant === "inlineInfo") {
             return (
               <div
                 key={event.indexOf(eventDetail)}


### PR DESCRIPTION
## What prompted this change?

The timeline localization refactor had reached the point where TimelineEvent was carrying too much manual branching for individual event titles. As more helper output moved to semantic titleKey and descriptionKey values, the component still relied on an ad hoc switch and a growing set of title-specific boolean checks. This change simplifies that rendering path so translation lookup and layout rules are clearer and easier to extend.

## Summary of changes

- replaced the manual title translation switch in TimelineEvent with a clearer key-to-translation mapping
- reduced title-specific branching by grouping event keys by rendering behaviour
- kept only the genuinely special cases explicit:
    - company events
    - enlistment/posting age rendering
    - stacked title layouts such as training, burial, and grave reference
- preserved generic rendering for standard titled events
- updated the timeline component test translation mock so semantic-key rendering stays deterministic in unit tests

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.