### PR TITLE
[NZT-145] Add birth year support

### DIFF
--- a/__tests__/unit/components/Profile/DiaryBirthInfo.test.tsx
+++ b/__tests__/unit/components/Profile/DiaryBirthInfo.test.tsx
@@ -46,6 +46,7 @@ test("renders birth country when known but not birth date when unknown", () => {
     <DiaryBirth
       birth={{
         ...mockBirth,
+        year: null,
         date: null,
       }}
     />
@@ -59,11 +60,48 @@ test("renders birth country when known but not birth date when unknown", () => {
   expect(screen.queryByText("18 December 1886")).not.toBeInTheDocument();
 });
 
+test("renders birth year when exact birth date is unknown", () => {
+  const mockComponent = (
+    <DiaryBirth
+      birth={{
+        ...mockBirth,
+        year: "1880",
+        date: null,
+      }}
+    />
+  );
+
+  render(mockComponent);
+
+  expect(findElementWithText("Born in New Zealand")).toBeInTheDocument();
+  expect(screen.getByText("1880")).toBeInTheDocument();
+  expect(screen.queryByText("18 December 1886")).not.toBeInTheDocument();
+});
+
+test("renders birth year when exact birth date and country are unknown", () => {
+  const mockComponent = (
+    <DiaryBirth
+      birth={{
+        ...mockBirth,
+        year: "1880",
+        date: null,
+        country: null,
+      }}
+    />
+  );
+
+  render(mockComponent);
+
+  expect(findElementWithText("Born")).toBeInTheDocument();
+  expect(screen.getByText("1880")).toBeInTheDocument();
+});
+
 test("does not render the component when birth date and country are unknown", () => {
   const { container } = render(
     <DiaryBirth
       birth={{
         ...mockBirth,
+        year: null,
         date: null,
         country: null,
       }}

--- a/__tests__/unit/components/Roll/Roll.test.tsx
+++ b/__tests__/unit/components/Roll/Roll.test.tsx
@@ -209,36 +209,6 @@ describe("Roll", () => {
     ).toBeInTheDocument();
   });
 
-  test("should filter unknown birth years", async () => {
-    await renderRoll();
-
-    const checkbox = screen.getByRole("checkbox", {
-      name: "Unknown birth year",
-    });
-    fireEvent.click(checkbox);
-    expect(screen.getByText("2 results")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", {
-        name: "Sapper Emmett Brown Main Body ?-1935 →",
-      }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("link", {
-        name: "Sapper John Doe Main Body 1886-1952 →",
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", {
-        name: "Driver Army Pay Corps Marty McFly 5th Reinforcements ?-†? →",
-      }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("link", {
-        name: "Sapper Biff Tanen 2nd Reinforcements 1897-†? →",
-      }),
-    ).toBeInTheDocument();
-  });
-
   test("should filter unknown death years", async () => {
     await renderRoll();
 
@@ -301,15 +271,6 @@ describe("Roll", () => {
       await renderRoll();
       const filterButton = screen.getByRole("button", { name: "Filters" });
       expect(within(filterButton).queryByText(/^\d+$/)).not.toBeInTheDocument();
-    });
-
-    test("shows badge count 1 when unknown birth year is unchecked", async () => {
-      await renderRoll();
-      fireEvent.click(
-        screen.getByRole("checkbox", { name: "Unknown birth year" }),
-      );
-      const filterButton = screen.getByRole("button", { name: /Filters/ });
-      expect(within(filterButton).getByText("1")).toBeInTheDocument();
     });
 
     test("shows badge count 1 when unknown death year is unchecked", async () => {

--- a/__tests__/unit/components/Roll/RollDetails/RollDetails.test.tsx
+++ b/__tests__/unit/components/Roll/RollDetails/RollDetails.test.tsx
@@ -35,6 +35,22 @@ describe("RollDetails", () => {
     expect(localStorage.getItem("tunnellers:return")).not.toBeNull();
   });
 
+  test("renders the birth year on the roll card", () => {
+    render(
+      <RollDetails
+        listOfTunnellers={[
+          {
+            ...tunnellers[0],
+            birthYear: "1880",
+            deathYear: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("1880-†?")).toBeInTheDocument();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/__tests__/unit/components/Roll/RollFilter/RollFilter.test.tsx
+++ b/__tests__/unit/components/Roll/RollFilter/RollFilter.test.tsx
@@ -38,7 +38,6 @@ const defaultProps = {
       "Non-Commissioned Officers": [],
       "Other Ranks": [],
     },
-    unknownBirthYear: "",
     unknownDeathYear: "",
   },
   startBirthYear: "1880",
@@ -52,7 +51,6 @@ const defaultProps = {
   handleSliderDragStart: jest.fn(),
   handleSliderDragComplete: jest.fn(),
   handleRankFilter: jest.fn(),
-  handleUnknownBirthYear: jest.fn(),
   handleUnknownDeathYear: jest.fn(),
 };
 
@@ -126,13 +124,6 @@ describe("RollFilter", () => {
     expect(defaultProps.handleRankFilter).toHaveBeenCalledWith({
       Officers: [10],
     });
-  });
-
-  test("calls handleUnknownBirthYear when the unknown birth year checkbox is clicked", () => {
-    render(<RollFilter {...defaultProps} />);
-    const checkbox = screen.getByLabelText("Unknown birth year");
-    fireEvent.click(checkbox);
-    expect(defaultProps.handleUnknownBirthYear).toHaveBeenCalledWith("unknown");
   });
 
   test("calls handleUnknownDeathYear when the unknown death year checkbox is clicked", () => {

--- a/__tests__/unit/components/Roll/__snapshots__/Roll.test.tsx.snap
+++ b/__tests__/unit/components/Roll/__snapshots__/Roll.test.tsx.snap
@@ -211,20 +211,6 @@ exports[`Roll matches the snapshot 1`] = `
                 />
               </div>
             </div>
-            <div
-              style="margin-top: 15px;"
-            >
-              <label>
-                <input
-                  checked=""
-                  id="unknownBirthYear"
-                  name="unknownBirthYear"
-                  type="checkbox"
-                  value="unknownBirthYear"
-                />
-                Unknown birth year
-              </label>
-            </div>
           </div>
           <div
             class="filters"

--- a/__tests__/unit/utils/database/getTunneller.test.ts
+++ b/__tests__/unit/utils/database/getTunneller.test.ts
@@ -28,6 +28,7 @@ describe("getTunneller", () => {
       forename: "John",
       surname: "Doe",
       birth_date: "1890-01-01",
+      birth_year: "1890",
       death_date: null,
       birth_country: "New Zealand",
       mother_name: null,
@@ -126,6 +127,16 @@ describe("getTunneller", () => {
         name: {
           forename: "John",
           surname: "Doe",
+        },
+        birth: "1890",
+      },
+      origins: {
+        birth: {
+          year: "1890",
+          date: {
+            year: "1890",
+            dayMonth: "1 January",
+          },
         },
       },
       militaryYears: {

--- a/__tests__/unit/utils/helpers/rollParams.test.ts
+++ b/__tests__/unit/utils/helpers/rollParams.test.ts
@@ -33,7 +33,6 @@ const defaultFilters: Filters = {
   corps: [],
   ranks: { Officers: [], "Non-Commissioned Officers": [], "Other Ranks": [] },
   birthYear: lookups.birthYears,
-  unknownBirthYear: "unknown",
   deathYear: lookups.deathYears,
   unknownDeathYear: "unknown",
 };
@@ -93,13 +92,6 @@ describe("filtersToSearchParams", () => {
     expect(qs).not.toContain("birth-min");
   });
 
-  test("sets unknown-birth=0 when unknowns excluded", () => {
-    const filters = { ...defaultFilters, unknownBirthYear: "" };
-    expect(filtersToSearchParams(filters, 1, "asc", lookups)).toContain(
-      "unknown-birth=0",
-    );
-  });
-
   test("does not encode commas as %2C", () => {
     const filters = { ...defaultFilters, detachment: [1, 2] };
     const qs = filtersToSearchParams(filters, 1, "asc", lookups);
@@ -127,7 +119,6 @@ describe("searchParamsToFilters", () => {
     expect(sortOrder).toBe("asc");
     expect(filters.detachment).toEqual([]);
     expect(filters.birthYear).toEqual(lookups.birthYears);
-    expect(filters.unknownBirthYear).toBe("unknown");
   });
 
   test("parses descending sort", () => {
@@ -169,11 +160,6 @@ describe("searchParamsToFilters", () => {
     expect(filters.birthYear).toEqual(["1886", "1897"]);
   });
 
-  test("sets unknownBirthYear to empty when unknown-birth=0", () => {
-    const { filters } = searchParamsToFilters(make("unknown-birth=0"), lookups);
-    expect(filters.unknownBirthYear).toBe("");
-  });
-
   test("round-trips filters through serialize then parse", () => {
     const original: Filters = {
       detachment: [1, 2],
@@ -184,7 +170,6 @@ describe("searchParamsToFilters", () => {
         "Other Ranks": [4],
       },
       birthYear: ["1886", "1897"],
-      unknownBirthYear: "",
       deathYear: ["1935", "1952"],
       unknownDeathYear: "unknown",
     };
@@ -199,6 +184,5 @@ describe("searchParamsToFilters", () => {
     expect(filters.corps).toEqual([null, 2]);
     expect(filters.ranks["Officers"]).toEqual([1]);
     expect(filters.birthYear).toEqual(["1886", "1897"]);
-    expect(filters.unknownBirthYear).toBe("");
   });
 });

--- a/app/[locale]/tunnellers/[slug]/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/page.tsx
@@ -39,7 +39,7 @@ export default async function Page(props: Props) {
 
   const { forename, surname } = tunneller.summary.name;
   const rank = tunneller.militaryYears.enlistment.rank;
-  const birthDate = tunneller.origins.birth.date?.year;
+  const birthDate = tunneller.summary.birth;
   const birthPlace = tunneller.origins.birth.country;
   const deathDate = tunneller.death?.date?.year;
   const deathTown = tunneller.death?.place?.town;

--- a/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
+++ b/app/[locale]/tunnellers/[slug]/wwi-timeline/page.tsx
@@ -52,7 +52,7 @@ export default async function Page(props: Props) {
 
   const { forename, surname } = tunneller.summary.name;
   const rank = tunneller.militaryYears.enlistment.rank;
-  const birthDate = tunneller.origins.birth.date?.year;
+  const birthDate = tunneller.summary.birth;
   const birthPlace = tunneller.origins.birth.country;
   const deathDate = tunneller.death?.date?.year;
   const deathTown = tunneller.death?.place?.town;

--- a/components/Profile/ProfileDiary/DiaryBirthInfo/DiaryBirthInfo.tsx
+++ b/components/Profile/ProfileDiary/DiaryBirthInfo/DiaryBirthInfo.tsx
@@ -16,24 +16,27 @@ export function DiaryBirth({ birth }: Props) {
   const locale = useLocale();
   const formatCountry = (country: string) =>
     locale === "fr" ? getFrenchCountryWithPrep(country) : country;
+  const birthDate = birth.date
+    ? `${birth.date.dayMonth} ${birth.date.year}`
+    : birth.year;
 
-  if (birth.date && birth.country) {
+  if (birthDate && birth.country) {
     return (
       <div className={STYLES["fullwidth-main-card"]}>
         <p>{t("bornInCountry", { country: formatCountry(birth.country) })}</p>
-        <span>{`${birth.date?.dayMonth} ${birth.date?.year}`}</span>
+        <span>{birthDate}</span>
       </div>
     );
   }
-  if (birth.date && !birth.country) {
+  if (birthDate && !birth.country) {
     return (
       <div className={STYLES["fullwidth-main-card"]}>
         <p>{t("born")}</p>
-        <span>{`${birth.date?.dayMonth} ${birth.date?.year}`}</span>
+        <span>{birthDate}</span>
       </div>
     );
   }
-  if (!birth.date && birth.country) {
+  if (!birthDate && birth.country) {
     return (
       <div className={STYLES["fullwidth-main-card"]}>
         <span>

--- a/components/Roll/RollFilter/RollFilter.tsx
+++ b/components/Roll/RollFilter/RollFilter.tsx
@@ -27,7 +27,6 @@ type Props = {
     ranks: {
       [key: string]: (number | null)[];
     };
-    unknownBirthYear: string;
     unknownDeathYear: string;
   };
   startBirthYear: string;
@@ -41,7 +40,6 @@ type Props = {
   handleSliderDragStart: () => void;
   handleSliderDragComplete: () => void;
   handleRankFilter: (rank: { [key: string]: (number | null)[] }) => void;
-  handleUnknownBirthYear: (unknownBirthYear: string) => void;
   handleUnknownDeathYear: (unknownDeathYear: string) => void;
 };
 
@@ -64,7 +62,6 @@ export function RollFilter({
   handleSliderDragStart,
   handleSliderDragComplete,
   handleRankFilter,
-  handleUnknownBirthYear,
   handleUnknownDeathYear,
 }: Props) {
   const t = useTranslations("roll");
@@ -146,23 +143,6 @@ export function RollFilter({
               },
             }}
           />
-        </div>
-        <div style={{ marginTop: "15px" }}>
-          <label>
-            <input
-              type="checkbox"
-              id={"unknownBirthYear"}
-              name={"unknownBirthYear"}
-              value={"unknownBirthYear"}
-              onChange={() =>
-                handleUnknownBirthYear(
-                  filters.unknownBirthYear === "unknown" ? "" : "unknown",
-                )
-              }
-              checked={filters.unknownBirthYear === "unknown" ? true : false}
-            />
-            {t("includesUnknownBirthYear")}
-          </label>
         </div>
       </div>
       <div className={STYLES.filters}>

--- a/components/Roll/hooks/useRollState.ts
+++ b/components/Roll/hooks/useRollState.ts
@@ -90,7 +90,6 @@ export function useRollState({ tunnellers, locale }: Params) {
         "Other Ranks": [],
       },
       birthYear: uniqueBirthYears,
-      unknownBirthYear: "unknown",
       deathYear: uniqueDeathYears,
       unknownDeathYear: "unknown",
     }),
@@ -216,9 +215,7 @@ export function useRollState({ tunnellers, locale }: Params) {
     );
     const detachmentActive = (currentFilters.detachment ?? []).length > 0;
     const corpsActive = (currentFilters.corps ?? []).length > 0;
-    const birthActive =
-      (currentFilters.birthYear ?? []).length > 0 ||
-      currentFilters.unknownBirthYear === "unknown";
+    const birthActive = (currentFilters.birthYear ?? []).length > 0;
     const deathActive =
       (currentFilters.deathYear ?? []).length > 0 ||
       currentFilters.unknownDeathYear === "unknown";
@@ -236,8 +233,7 @@ export function useRollState({ tunnellers, locale }: Params) {
     Object.values(filters.ranks ?? {}).some((arr) => arr.length),
     (filters.detachment ?? []).length > 0,
     (filters.corps ?? []).length > 0,
-    (filters.birthYear ?? []).length < uniqueBirthYears.length ||
-      filters.unknownBirthYear === "",
+    (filters.birthYear ?? []).length < uniqueBirthYears.length,
     (filters.deathYear ?? []).length < uniqueDeathYears.length ||
       filters.unknownDeathYear === "",
   ].filter(Boolean).length;
@@ -271,13 +267,14 @@ export function useRollState({ tunnellers, locale }: Params) {
             );
           })
           .filter((tunneller) => {
-            const wantsUnknown = filters.unknownBirthYear === "unknown";
             const list = filters.birthYear ?? [];
-            if (wantsUnknown && tunneller.birthYear === null) return true;
+            if (tunneller.birthYear === null) {
+              return list.length === uniqueBirthYears.length;
+            }
             if (list.length && tunneller.birthYear) {
               return list.includes(tunneller.birthYear);
             }
-            return !wantsUnknown && list.length === 0;
+            return false;
           })
           .filter((tunneller) => {
             const wantsUnknown = filters.unknownDeathYear === "unknown";
@@ -290,7 +287,7 @@ export function useRollState({ tunnellers, locale }: Params) {
           }),
       ])
       .filter(([, list]) => list.length > 0);
-  }, [filters, tunnellersList, hasAnyActiveFilter]);
+  }, [filters, tunnellersList, hasAnyActiveFilter, uniqueBirthYears.length]);
 
   const totalFilteredTunnellers = useMemo(
     () => filteredGroups.reduce((acc, [, list]) => acc + list.length, 0),
@@ -366,17 +363,6 @@ export function useRollState({ tunnellers, locale }: Params) {
       setPageToFirst();
     },
     [uniqueBirthYears, setPageToFirst],
-  );
-
-  const handleUnknownBirthYear = useCallback(
-    (unknown: string) => {
-      setFilters((prev) => ({
-        ...prev,
-        unknownBirthYear: unknown ? "unknown" : "",
-      }));
-      setPageToFirst();
-    },
-    [setPageToFirst],
   );
 
   const handleDeathSliderChange = useCallback(
@@ -466,7 +452,6 @@ export function useRollState({ tunnellers, locale }: Params) {
     handleSliderDragStart,
     handleSliderDragComplete,
     handleRankFilter,
-    handleUnknownBirthYear,
     handleUnknownDeathYear,
   };
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -230,6 +230,7 @@ The database holds data for:
 | `section_fk`                      | `tinyint`  | Foreign | `NULL`  | Sections in the Main Body                                     |
 | `attached_corps_fk`               | `tinyint`  | Foreign | `NULL`  | Attached personnel                                            |
 | `birth_date`                      | `date`     | -       | `NULL`  | Date of birth                                                 |
+| `birth_year`                      | `smallint` | -       | `NULL`  | Year of birth when full date is unknown                       |
 | `birth_country_fk`                | `tinyint`  | Foreign | `NULL`  | Country of birth                                              |
 | `mother_name`                     | `varchar`  | -       | `NULL`  | Mother's name                                                 |
 | `mother_origin_fk`                | `tinyint`  | Foreign | `NULL`  | Mother's country of origin                                    |

--- a/messages/en.json
+++ b/messages/en.json
@@ -75,7 +75,6 @@
     "rankOfficers": "Officers",
     "rankNco": "Non-Commissioned Officers",
     "rankOtherRanks": "Other Ranks",
-    "includesUnknownBirthYear": "Unknown birth year",
     "includesUnknownDeathYear": "Unknown death year",
     "noResults": "Sorry, no profile matches your filters",
     "clearFilters": "Clear Filters",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -75,7 +75,6 @@
     "rankOfficers": "Officiers",
     "rankNco": "Sous-officiers",
     "rankOtherRanks": "Autres grades",
-    "includesUnknownBirthYear": "Années de naissance inconnues",
     "includesUnknownDeathYear": "Années de décès inconnues",
     "noResults": "Aucun profil ne correspond à vos filtres",
     "clearFilters": "Supprimer les filtres",

--- a/test-utils/mocks/mockTunneller.ts
+++ b/test-utils/mocks/mockTunneller.ts
@@ -43,6 +43,7 @@ export const mockSummary: Summary = {
 
 // Origins
 export const mockBirth: Birth = {
+  year: "1886",
   date: {
     year: "1886",
     dayMonth: "18 December",

--- a/types/tunneller.ts
+++ b/types/tunneller.ts
@@ -7,6 +7,7 @@ export type ProfileData = {
   surname: string;
   forename: string;
   birth_date: string | null;
+  birth_year: string | null;
   death_date: string | null;
   birth_country: string | null;
   mother_name: string | null;
@@ -133,6 +134,7 @@ export type Summary = {
 };
 
 export type Birth = {
+  year: string | null;
   date: DateObj | null;
   country: string | null;
 };

--- a/utils/database/getTunneller.ts
+++ b/utils/database/getTunneller.ts
@@ -207,11 +207,16 @@ export async function getTunneller(
         forename: profile.forename,
         surname: profile.surname,
       },
-      birth: profile.birth_date ? getYear(profile.birth_date) : null,
+      birth:
+        profile.birth_year ??
+        (profile.birth_date ? getYear(profile.birth_date) : null),
       death: profile.death_date ? getYear(profile.death_date) : null,
     },
     origins: {
       birth: {
+        year:
+          profile.birth_year ??
+          (profile.birth_date ? getYear(profile.birth_date) : null),
         date: profile.birth_date ? getDate(profile.birth_date) : null,
         country: profile.birth_country,
       },

--- a/utils/database/queries/rollQuery.ts
+++ b/utils/database/queries/rollQuery.ts
@@ -8,7 +8,7 @@ export const rollQuery = async (locale: Locale, connection: PoolConnection) => {
     , t.slug
     , t.surname
     , t.forename
-    , DATE_FORMAT(t.birth_date, '%Y') AS birthYear
+    , CAST(COALESCE(t.birth_year, YEAR(t.birth_date)) AS CHAR) AS birthYear
     , DATE_FORMAT(t.death_date, '%Y') AS deathYear
     , embarkation_unit.embarkation_unit_${locale} AS detachment
     , embarkation_unit.embarkation_unit_en AS detachment_en

--- a/utils/database/queries/tunnellerQuery.ts
+++ b/utils/database/queries/tunnellerQuery.ts
@@ -13,6 +13,7 @@ export const tunnellerQuery = async (
     , t.surname
     , t.forename
     , DATE_FORMAT(t.birth_date, '%Y-%m-%d') AS birth_date
+    , CAST(COALESCE(t.birth_year, YEAR(t.birth_date)) AS CHAR) AS birth_year
     , DATE_FORMAT(t.death_date, '%Y-%m-%d') AS death_date
     , birth_country.country_${locale} AS birth_country
     , t.mother_name

--- a/utils/helpers/rollParams.ts
+++ b/utils/helpers/rollParams.ts
@@ -7,7 +7,6 @@ export type Filters = {
   corps: (number | null)[];
   ranks: Record<string, (number | null)[]>;
   birthYear: string[];
-  unknownBirthYear: string;
   deathYear: string[];
   unknownDeathYear: string;
 };
@@ -93,7 +92,6 @@ export function searchParamsToFilters(
         }),
       ),
       birthYear,
-      unknownBirthYear: params.get("unknown-birth") === "0" ? "" : "unknown",
       deathYear,
       unknownDeathYear: params.get("unknown-death") === "0" ? "" : "unknown",
     },
@@ -143,8 +141,6 @@ export function filtersToSearchParams(
     params.set("birth-min", filters.birthYear[0]);
     params.set("birth-max", filters.birthYear[filters.birthYear.length - 1]);
   }
-
-  if (filters.unknownBirthYear === "") params.set("unknown-birth", "0");
 
   if (
     filters.deathYear.length < lookups.deathYears.length &&


### PR DESCRIPTION
## What prompted this change?

All tunnellers now have a known birth year in the database, including records where only the year is known. The app needed to use the new `birth_year` column without inventing day/month values, and the roll filters no longer need an `Unknown birth year` option.

## Summary of changes

- Added `birth_year` to the tunneller data shape and database docs.
- Used `birth_year` for roll cards, roll filters, profile birth display, and JSON-LD, while keeping `birth_date` for exact day/month display.
- Removed the `Unknown birth year` roll filter and its URL parameter.
- Updated unit tests and roll snapshots.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [x] If appropriate, documentation created or updated.