### PR TITLE
[NZT-153] Fix React 418

### DIFF
--- a/__tests__/e2e/books.spec.ts
+++ b/__tests__/e2e/books.spec.ts
@@ -259,6 +259,7 @@ test("EN HowToCite: shows correct citation for a book chapter", async ({
     "Chapter 1: The Tunnellers from the Antipodes",
   );
   await expect(citation).toContainText("Kiwis Dig Tunnels Too");
+  await expect(citation).toContainText("Available at:");
   await expect(citation).toContainText("Accessed");
   await expect(citation).toContainText(
     "www.nztunnellers.com/books/kiwis-dig-tunnels-too/chapter-1-the-tunnellers-from-the-antipodes",
@@ -278,6 +279,7 @@ test("FR HowToCite: shows correct citation for a book chapter", async ({
   await expect(citation).toContainText("Anthony Byledbal");
   await expect(citation).toContainText("Les Tunneliers des antipodes");
   await expect(citation).toContainText("Les Kiwis aussi creusent des tunnels");
+  await expect(citation).toContainText("Disponible à\u00A0:");
   await expect(citation).toContainText("Consulté le");
   await expect(citation).toContainText(
     "www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapter-1-the-tunnellers-from-the-antipodes",

--- a/__tests__/unit/components/Article/Article.test.tsx
+++ b/__tests__/unit/components/Article/Article.test.tsx
@@ -70,7 +70,7 @@ describe("Article", () => {
     expect(findElementWithText("My Awesome Article Title")).toBeInTheDocument();
     expect(screen.getByText(/history\/my-awesome-article/)).toBeInTheDocument();
     expect(screen.getByText(/\(2009\)/)).toBeInTheDocument();
-    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/\(Accessed: 4 May 2023\)\./)).toBeInTheDocument();
   });
 
   test("does not render the next chapter link when null", () => {

--- a/__tests__/unit/components/Article/Article.test.tsx
+++ b/__tests__/unit/components/Article/Article.test.tsx
@@ -69,7 +69,8 @@ describe("Article", () => {
     ).toBeInTheDocument();
     expect(findElementWithText("My Awesome Article Title")).toBeInTheDocument();
     expect(screen.getByText(/history\/my-awesome-article/)).toBeInTheDocument();
-    expect(screen.getByText(/Accessed: 4 May 2023/)).toBeInTheDocument();
+    expect(screen.getByText(/\(2009\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
   });
 
   test("does not render the next chapter link when null", () => {

--- a/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
+++ b/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`Article matches the snapshot 1`] = `
         <em>
           New Zealand Tunnellers Website
         </em>
-        , 2023 (2009), Accessed: 4 May 2023. 
+         (2009). 
         <span>
           URL: 
           <wbr />

--- a/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
+++ b/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
@@ -196,6 +196,7 @@ exports[`Article matches the snapshot 1`] = `
           <wbr />
           www.nztunnellers.com/history/my-awesome-article
         </span>
+         (Accessed: 4 May 2023).
       </p>
     </div>
   </div>

--- a/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
+++ b/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
@@ -186,13 +186,13 @@ exports[`Article matches the snapshot 1`] = `
         </button>
       </h3>
       <p>
-        Anthony Byledbal, “My Awesome Article Title”, 
+        Anthony Byledbal, 
         <em>
-          New Zealand Tunnellers Website
+          My Awesome Article Title
         </em>
-         (2009). 
+        , New Zealand Tunnellers Website (2009). 
         <span>
-          URL: 
+          Available at: 
           <wbr />
           www.nztunnellers.com/history/my-awesome-article
         </span>

--- a/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
+++ b/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`Chapter matches the snapshot 1`] = `
           <wbr />
           www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapitre-1-les-tunneliers-des-antipodes
         </span>
+         (Consulté le : 1 janvier 2025).
       </p>
     </div>
     <a

--- a/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
+++ b/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`Chapter matches the snapshot 1`] = `
         </em>
         , New Zealand Tunnellers Website (2009). 
         <span>
-          URL : 
+          Disponible à : 
           <wbr />
           www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapitre-1-les-tunneliers-des-antipodes
         </span>

--- a/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
+++ b/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`Chapter matches the snapshot 1`] = `
         <em>
           Les Kiwis aussi creusent des tunnels
         </em>
-        , New Zealand Tunnellers Website, 2025 (2009), Consulté le : 1 janvier 2025. 
+        , New Zealand Tunnellers Website (2009). 
         <span>
           URL : 
           <wbr />

--- a/__tests__/unit/components/HowToCite/HowToCite.test.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.test.tsx
@@ -1,8 +1,17 @@
 import { render } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
 
 import { HowToCite } from "@/components/HowToCite/HowToCite";
 
 describe("HowToCite", () => {
+  test("omits browser-only accessed date during server rendering", () => {
+    const html = renderToString(
+      <HowToCite title="Beneath Artois Fields" locale="en" />,
+    );
+
+    expect(html).not.toContain("Accessed:");
+  });
+
   test("does not italicize the site title for regular page citations", () => {
     const { container } = render(
       <HowToCite title="Beneath Artois Fields" locale="en" />,

--- a/__tests__/unit/components/HowToCite/HowToCite.test.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import { HowToCite } from "@/components/HowToCite/HowToCite";
 
 describe("HowToCite", () => {
-  test("italicizes the site title for regular page citations", () => {
+  test("does not italicize the site title for regular page citations", () => {
     const { container } = render(
       <HowToCite title="Beneath Artois Fields" locale="en" />,
     );
@@ -12,7 +12,11 @@ describe("HowToCite", () => {
       (element) => element.textContent,
     );
 
-    expect(emphasized).toContain("New Zealand Tunnellers Website");
+    expect(emphasized).toContain("Beneath Artois Fields");
+    expect(emphasized).not.toContain("New Zealand Tunnellers Website");
+    expect(container.querySelector("p")).toHaveTextContent(
+      "New Zealand Tunnellers Website",
+    );
   });
 
   test("italicizes the book title instead of the site title for book citations", () => {

--- a/__tests__/unit/components/HowToCite/HowToCite.text.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.text.tsx
@@ -161,7 +161,7 @@ describe("HowToCite", () => {
     );
 
     expect(screen.getByText(/Chapter 1:/)).toBeInTheDocument();
-    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/\(Accessed:/)).toBeInTheDocument();
   });
 
   test("renders chapter citation with chapter number and title", () => {

--- a/__tests__/unit/components/HowToCite/HowToCite.text.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.text.tsx
@@ -14,7 +14,9 @@ global.alert = jest.fn();
 
 describe("HowToCite", () => {
   test("shows English success alert on clipboard copy", async () => {
-    jest.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+    const writeTextSpy = jest
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
 
     const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
 
@@ -23,6 +25,9 @@ describe("HowToCite", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy to clipboard" }));
 
     await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/URL: www\.nztunnellers\.com\/\. Accessed: /),
+      );
       expect(alertSpy).toHaveBeenCalledWith(
         "How to cite has been copied to clipboard",
       );
@@ -54,7 +59,9 @@ describe("HowToCite", () => {
   });
 
   test("shows French success alert on clipboard copy", async () => {
-    jest.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+    const writeTextSpy = jest
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
 
     const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
 
@@ -65,6 +72,11 @@ describe("HowToCite", () => {
     );
 
     await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /URL\u00A0: www\.nztunnellers\.com\/fr\/\. Consulté le\u00A0: /,
+        ),
+      );
       expect(alertSpy).toHaveBeenCalledWith(
         "Comment citer a été copié dans le presse-papiers",
       );
@@ -147,6 +159,7 @@ describe("HowToCite", () => {
     );
 
     expect(screen.getByText(/Chapter 1:/)).toBeInTheDocument();
+    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
   });
 
   test("renders chapter citation with chapter number and title", () => {

--- a/__tests__/unit/components/HowToCite/HowToCite.text.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.text.tsx
@@ -20,13 +20,15 @@ describe("HowToCite", () => {
 
     const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
 
-    render(<HowToCite />);
+    render(<HowToCite title="Beneath Artois Fields" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Copy to clipboard" }));
 
     await waitFor(() => {
       expect(writeTextSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/URL: www\.nztunnellers\.com\/\. Accessed: /),
+        expect.stringMatching(
+          /^Anthony Byledbal, Beneath Artois Fields, New Zealand Tunnellers Website \(2009\)\. Available at: www\.nztunnellers\.com\/history\/beneath-artois-fields \(Accessed: .+\)\.$/,
+        ),
       );
       expect(alertSpy).toHaveBeenCalledWith(
         "How to cite has been copied to clipboard",
@@ -65,7 +67,7 @@ describe("HowToCite", () => {
 
     const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
 
-    render(<HowToCite locale="fr" />);
+    render(<HowToCite title="Sous Arras" locale="fr" />);
 
     fireEvent.click(
       screen.getByRole("button", { name: "Copier dans le presse-papiers" }),
@@ -74,7 +76,7 @@ describe("HowToCite", () => {
     await waitFor(() => {
       expect(writeTextSpy).toHaveBeenCalledWith(
         expect.stringMatching(
-          /URL\u00A0: www\.nztunnellers\.com\/fr\/\. Consulté le\u00A0: /,
+          /^Anthony Byledbal, Sous Arras, New Zealand Tunnellers Website \(2009\)\. Disponible à\u00A0: www\.nztunnellers\.com\/fr\/history\/sous-arras \(Consulté le\u00A0: .+\)\.$/,
         ),
       );
       expect(alertSpy).toHaveBeenCalledWith(

--- a/__tests__/unit/components/HowToCite/utils/citationFormatters.test.ts
+++ b/__tests__/unit/components/HowToCite/utils/citationFormatters.test.ts
@@ -2,6 +2,7 @@ import {
   buildCitationTitle,
   buildCitationUrl,
   formatBookSubpath,
+  getCitationAvailableAtLabel,
 } from "@/components/HowToCite/utils/citationFormatters";
 
 describe("citationFormatters", () => {
@@ -39,7 +40,7 @@ describe("citationFormatters", () => {
         timeline: true,
         locale: "en",
       }),
-    ).toBe("“World War I Timeline of John Doe”");
+    ).toBe("World War I Timeline of John Doe");
   });
 
   test("builds a history article URL from a title", () => {
@@ -65,5 +66,10 @@ describe("citationFormatters", () => {
     expect(
       formatBookSubpath("/book/chapter-12-bridging-at-the-end", "en"),
     ).toBe("Chapter 12: Bridging at the end");
+  });
+
+  test("gets the translated available at label", () => {
+    expect(getCitationAvailableAtLabel("en")).toBe("Available at: ");
+    expect(getCitationAvailableAtLabel("fr")).toBe("Disponible à\u00A0: ");
   });
 });

--- a/__tests__/unit/components/Profile/Profile.test.tsx
+++ b/__tests__/unit/components/Profile/Profile.test.tsx
@@ -169,7 +169,8 @@ describe("Profile", () => {
     ).toBeInTheDocument();
 
     expect(findElementWithText("John Smith (1886-1966)")).toBeInTheDocument();
-    expect(screen.getByText(/Accessed: 4 May 2023/)).toBeInTheDocument();
+    expect(screen.getByText(/\(2009\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
     expect(
       screen.getByText(
         /URL: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415/,

--- a/__tests__/unit/components/Profile/Profile.test.tsx
+++ b/__tests__/unit/components/Profile/Profile.test.tsx
@@ -170,7 +170,7 @@ describe("Profile", () => {
 
     expect(findElementWithText("John Smith (1886-1966)")).toBeInTheDocument();
     expect(screen.getByText(/\(2009\)/)).toBeInTheDocument();
-    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/\(Accessed: 4 May 2023\)\./)).toBeInTheDocument();
     expect(
       screen.getByText(
         /Available at: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415/,

--- a/__tests__/unit/components/Profile/Profile.test.tsx
+++ b/__tests__/unit/components/Profile/Profile.test.tsx
@@ -173,7 +173,7 @@ describe("Profile", () => {
     expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
     expect(
       screen.getByText(
-        /URL: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415/,
+        /Available at: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415/,
       ),
     ).toBeInTheDocument();
   });

--- a/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
+++ b/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
@@ -358,6 +358,7 @@ exports[`Profile matches the snapshot 1`] = `
             <wbr />
             www.nztunnellers.com/tunnellers/harry-corrin--4_1415
           </span>
+           (Accessed: 4 May 2023).
         </p>
       </div>
     </div>

--- a/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
+++ b/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
@@ -353,7 +353,7 @@ exports[`Profile matches the snapshot 1`] = `
           <em>
             New Zealand Tunnellers Website
           </em>
-          , 2023 (2009), Accessed: 4 May 2023. 
+           (2009). 
           <span>
             URL: 
             <wbr />

--- a/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
+++ b/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
@@ -349,13 +349,12 @@ exports[`Profile matches the snapshot 1`] = `
           </button>
         </h3>
         <p>
-          “John Smith (1886-1966)”, 
           <em>
-            New Zealand Tunnellers Website
+            John Smith (1886-1966)
           </em>
-           (2009). 
+          , New Zealand Tunnellers Website (2009). 
           <span>
-            URL: 
+            Available at: 
             <wbr />
             www.nztunnellers.com/tunnellers/harry-corrin--4_1415
           </span>

--- a/__tests__/unit/components/Timeline/Timeline.test.tsx
+++ b/__tests__/unit/components/Timeline/Timeline.test.tsx
@@ -63,7 +63,7 @@ describe("Timeline", () => {
       findElementWithText("World War I Timeline of John Smith"),
     ).toBeInTheDocument();
     expect(screen.getByText(/\(2009\)/)).toBeInTheDocument();
-    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/\(Accessed: 4 May 2023\)\./)).toBeInTheDocument();
     expect(
       screen.getByText(
         /Available at: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415\/wwi-timeline/,

--- a/__tests__/unit/components/Timeline/Timeline.test.tsx
+++ b/__tests__/unit/components/Timeline/Timeline.test.tsx
@@ -66,7 +66,7 @@ describe("Timeline", () => {
     expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
     expect(
       screen.getByText(
-        /URL: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415\/wwi-timeline/,
+        /Available at: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415\/wwi-timeline/,
       ),
     ).toBeInTheDocument();
   });

--- a/__tests__/unit/components/Timeline/Timeline.test.tsx
+++ b/__tests__/unit/components/Timeline/Timeline.test.tsx
@@ -62,7 +62,8 @@ describe("Timeline", () => {
     expect(
       findElementWithText("World War I Timeline of John Smith"),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Accessed: 4 May 2023/)).toBeInTheDocument();
+    expect(screen.getByText(/\(2009\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/Accessed:/)).not.toBeInTheDocument();
     expect(
       screen.getByText(
         /URL: www.nztunnellers.com\/tunnellers\/harry-corrin--4_1415\/wwi-timeline/,

--- a/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
@@ -463,6 +463,7 @@ exports[`Timeline matches the snapshot 1`] = `
           <wbr />
           www.nztunnellers.com/tunnellers/harry-corrin--4_1415/wwi-timeline
         </span>
+         (Accessed: 4 May 2023).
       </p>
     </div>
   </div>

--- a/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
@@ -454,13 +454,12 @@ exports[`Timeline matches the snapshot 1`] = `
         </button>
       </h3>
       <p>
-        “World War I Timeline of John Smith”, 
         <em>
-          New Zealand Tunnellers Website
+          World War I Timeline of John Smith
         </em>
-         (2009). 
+        , New Zealand Tunnellers Website (2009). 
         <span>
-          URL: 
+          Available at: 
           <wbr />
           www.nztunnellers.com/tunnellers/harry-corrin--4_1415/wwi-timeline
         </span>

--- a/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
@@ -458,7 +458,7 @@ exports[`Timeline matches the snapshot 1`] = `
         <em>
           New Zealand Tunnellers Website
         </em>
-        , 2023 (2009), Accessed: 4 May 2023. 
+         (2009). 
         <span>
           URL: 
           <wbr />

--- a/components/HowToCite/HowToCite.tsx
+++ b/components/HowToCite/HowToCite.tsx
@@ -13,6 +13,7 @@ import {
   buildCitationUrl,
   formatCitationDate,
   formatBookSubpath,
+  getCitationAvailableAtLabel,
 } from "./utils/citationFormatters";
 
 type Props = {
@@ -51,12 +52,12 @@ export function HowToCiteUrl({
     pathname,
     locale,
   });
-  const urlLabel = locale === "fr" ? "URL\u00A0: " : "URL: ";
+  const availableAtLabel = getCitationAvailableAtLabel(locale);
 
   if (pathname) {
     return (
       <span>
-        {urlLabel}
+        {availableAtLabel}
         <wbr />
         {fullUrl}
       </span>
@@ -65,7 +66,7 @@ export function HowToCiteUrl({
 
   return (
     <span>
-      {urlLabel}
+      {availableAtLabel}
       <wbr />
       {fullUrl}
     </span>
@@ -125,8 +126,8 @@ export function HowToCite({
     const now = new Date();
     const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const currentDate = formatCitationDate(now, locale, userTimeZone);
-    const urlLabel = locale === "fr" ? "URL\u00A0: " : "URL: ";
-    const citationText = `${citationAuthorPrefix}${citationTextTitle}, New Zealand Tunnellers Website (2009). ${urlLabel}${citationUrl}. ${accessedLabel}${currentDate}.`;
+    const availableAtLabel = getCitationAvailableAtLabel(locale);
+    const citationText = `${citationAuthorPrefix}${citationTextTitle}, New Zealand Tunnellers Website (2009). ${availableAtLabel}${citationUrl} (${accessedLabel}${currentDate}).`;
 
     navigator.clipboard
       .writeText(citationText)
@@ -178,14 +179,9 @@ export function HowToCite({
             <em>{bookTitle(locale)}</em>
           </>
         ) : (
-          citationTitle
+          <em>{citationTitle}</em>
         )}
-        ,{" "}
-        {citationChapterTitle ? (
-          "New Zealand Tunnellers Website"
-        ) : (
-          <em>New Zealand Tunnellers Website</em>
-        )}
+        , New Zealand Tunnellers Website
         {" (2009). "}
         <HowToCiteUrl
           tunnellerSlug={tunnellerSlug}

--- a/components/HowToCite/HowToCite.tsx
+++ b/components/HowToCite/HowToCite.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useLocale } from "next-intl";
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 import type { Summary } from "@/types/tunneller";
 import { bookTitle } from "@/utils/helpers/books/basePathUtil";
@@ -35,6 +35,17 @@ type HowToCiteUrlProps = {
   pathname?: string;
   locale?: string;
 };
+
+const subscribeToCitationAccessDate = () => () => {};
+const getServerCitationAccessDate = () => null;
+
+function formatCitationAccessDate(locale: string, accessedLabel: string) {
+  const now = new Date();
+  const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const currentDate = formatCitationDate(now, locale, userTimeZone);
+
+  return ` (${accessedLabel}${currentDate}).`;
+}
 
 export function HowToCiteUrl({
   tunnellerSlug,
@@ -86,6 +97,11 @@ export function HowToCite({
   const localeFromContext = useLocale();
   const locale = localeProp ?? localeFromContext;
   const accessedLabel = locale === "en" ? "Accessed: " : "Consulté le\u00A0: ";
+  const accessDate = useSyncExternalStore(
+    subscribeToCitationAccessDate,
+    () => formatCitationAccessDate(locale, accessedLabel),
+    getServerCitationAccessDate,
+  );
   const citationAuthorPrefix = summary ? "" : "Anthony Byledbal, ";
   const citationTitle = useMemo(
     () =>
@@ -191,6 +207,7 @@ export function HowToCite({
           pathname={pathname}
           locale={locale}
         />
+        {accessDate}
       </p>
     </div>
   );

--- a/components/HowToCite/HowToCite.tsx
+++ b/components/HowToCite/HowToCite.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useLocale } from "next-intl";
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import type { Summary } from "@/types/tunneller";
 import { bookTitle } from "@/utils/helpers/books/basePathUtil";
@@ -13,7 +13,6 @@ import {
   buildCitationUrl,
   formatCitationDate,
   formatBookSubpath,
-  formatCitationYear,
 } from "./utils/citationFormatters";
 
 type Props = {
@@ -85,21 +84,6 @@ export function HowToCite({
 }: Props) {
   const localeFromContext = useLocale();
   const locale = localeProp ?? localeFromContext;
-  const citationRef = useRef<HTMLParagraphElement>(null);
-
-  const now = useMemo(() => new Date(), []);
-  const userTimeZone = useMemo(
-    () => Intl.DateTimeFormat().resolvedOptions().timeZone,
-    [],
-  );
-  const currentDate = useMemo(
-    () => formatCitationDate(now, locale, userTimeZone),
-    [locale, now, userTimeZone],
-  );
-  const currentYear = useMemo(
-    () => formatCitationYear(now, locale, userTimeZone),
-    [locale, now, userTimeZone],
-  );
   const accessedLabel = locale === "en" ? "Accessed: " : "Consulté le\u00A0: ";
   const citationAuthorPrefix = summary ? "" : "Anthony Byledbal, ";
   const citationTitle = useMemo(
@@ -119,31 +103,51 @@ export function HowToCite({
       pathname ? (chapterTitle ?? formatBookSubpath(pathname, locale)) : null,
     [chapterTitle, pathname, locale],
   );
+  const citationTextTitle = useMemo(() => {
+    if (!citationChapterTitle) return citationTitle;
+
+    return `${locale === "en" ? "\u201C" : "«\u00A0"}${citationChapterTitle}${locale === "en" ? "\u201D" : "\u00A0»"}, in ${bookTitle(locale)}`;
+  }, [citationChapterTitle, citationTitle, locale]);
+  const citationUrl = useMemo(
+    () =>
+      buildCitationUrl({
+        tunnellerSlug,
+        title,
+        slug,
+        timeline,
+        pathname,
+        locale,
+      }),
+    [tunnellerSlug, title, slug, timeline, pathname, locale],
+  );
 
   const handleCopy = () => {
-    if (citationRef.current) {
-      const citationText = citationRef.current.innerText;
-      navigator.clipboard
-        .writeText(citationText)
-        .then(() => {
-          alert(
-            locale === "en"
-              ? "How to cite has been copied to clipboard"
-              : "Comment citer a été copié dans le presse-papiers",
-          );
-        })
-        .catch((err) => {
-          alert(
-            locale === "en"
-              ? "Failed to copy to clipboard. Please try selecting and copying the text manually."
-              : "Échec de la copie dans le presse-papiers. Veuillez essayer de sélectionner et de copier le texte manuellement.",
-          );
-          // Only log errors in development
-          if (process.env.NODE_ENV === "development") {
-            console.error("Failed to copy: ", err);
-          }
-        });
-    }
+    const now = new Date();
+    const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const currentDate = formatCitationDate(now, locale, userTimeZone);
+    const urlLabel = locale === "fr" ? "URL\u00A0: " : "URL: ";
+    const citationText = `${citationAuthorPrefix}${citationTextTitle}, New Zealand Tunnellers Website (2009). ${urlLabel}${citationUrl}. ${accessedLabel}${currentDate}.`;
+
+    navigator.clipboard
+      .writeText(citationText)
+      .then(() => {
+        alert(
+          locale === "en"
+            ? "How to cite has been copied to clipboard"
+            : "Comment citer a été copié dans le presse-papiers",
+        );
+      })
+      .catch((err) => {
+        alert(
+          locale === "en"
+            ? "Failed to copy to clipboard. Please try selecting and copying the text manually."
+            : "Échec de la copie dans le presse-papiers. Veuillez essayer de sélectionner et de copier le texte manuellement.",
+        );
+        // Only log errors in development
+        if (process.env.NODE_ENV === "development") {
+          console.error("Failed to copy: ", err);
+        }
+      });
   };
 
   return (
@@ -164,7 +168,7 @@ export function HowToCite({
           />
         </button>
       </h3>
-      <p ref={citationRef}>
+      <p>
         {citationAuthorPrefix}
         {citationChapterTitle ? (
           <>
@@ -182,9 +186,7 @@ export function HowToCite({
         ) : (
           <em>New Zealand Tunnellers Website</em>
         )}
-        {`, ${currentYear} (2009), ${accessedLabel}`}
-        {currentDate}
-        {". "}
+        {" (2009). "}
         <HowToCiteUrl
           tunnellerSlug={tunnellerSlug}
           title={title}

--- a/components/HowToCite/utils/citationFormatters.ts
+++ b/components/HowToCite/utils/citationFormatters.ts
@@ -135,14 +135,3 @@ export function formatCitationDate(
     timeZone,
   }).format(now);
 }
-
-export function formatCitationYear(
-  now: Date,
-  locale: string,
-  timeZone: string,
-) {
-  return new Intl.DateTimeFormat(locale === "en" ? "en-NZ" : "fr-FR", {
-    year: "numeric",
-    timeZone,
-  }).format(now);
-}

--- a/components/HowToCite/utils/citationFormatters.ts
+++ b/components/HowToCite/utils/citationFormatters.ts
@@ -1,3 +1,5 @@
+import enMessages from "@/messages/en.json";
+import frMessages from "@/messages/fr.json";
 import type { Summary } from "@/types/tunneller";
 import { bookTitle } from "@/utils/helpers/books/basePathUtil";
 import { displayBiographyDates } from "@/utils/helpers/roll";
@@ -19,6 +21,11 @@ type CitationUrlParams = {
   pathname?: string;
   locale?: string;
 };
+
+const messagesByLocale = {
+  en: enMessages,
+  fr: frMessages,
+} as const;
 
 export function sentenceCase(str: string): string {
   const lower = str.toLowerCase();
@@ -73,7 +80,7 @@ export function buildCitationTitle({
   }
 
   if (summary && !timeline) {
-    return `${openQuote}${summary.name.forename} ${summary.name.surname} (${displayBiographyDates(summary.birth, summary.death)})${closeQuote}`;
+    return `${summary.name.forename} ${summary.name.surname} (${displayBiographyDates(summary.birth, summary.death)})`;
   }
 
   if (summary && timeline) {
@@ -81,11 +88,11 @@ export function buildCitationTitle({
       locale === "en"
         ? "World War I Timeline of"
         : "Chronologie de la guerre de";
-    return `${openQuote}${timelineOf} ${summary.name.forename} ${summary.name.surname}${closeQuote}`;
+    return `${timelineOf} ${summary.name.forename} ${summary.name.surname}`;
   }
 
   const articleTitle = title?.replace(/\\/g, " ") ?? "";
-  return `${openQuote}${articleTitle}${closeQuote}`;
+  return articleTitle;
 }
 
 export function buildCitationUrl({
@@ -121,6 +128,14 @@ export function buildCitationUrl({
   }
 
   return `www.nztunnellers.com${localePrefix}/`;
+}
+
+export function getCitationAvailableAtLabel(locale: string): string {
+  const messages =
+    messagesByLocale[locale as keyof typeof messagesByLocale] ??
+    messagesByLocale.en;
+
+  return messages.howToCite.availableAt;
 }
 
 export function formatCitationDate(

--- a/messages/en.json
+++ b/messages/en.json
@@ -13,6 +13,9 @@
     "historyChapterDescription": "Read about {title} - history of the New Zealand Tunnellers during the First World War",
     "bookChapterDescription": "Read {title} - a chapter from Kiwis Dig Tunnels Too, about the New Zealand Tunnellers in WWI"
   },
+  "howToCite": {
+    "availableAt": "Available at: "
+  },
   "nav": {
     "history": "History",
     "tunnellers": "Tunnellers",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -13,6 +13,9 @@
     "historyChapterDescription": "Lire le chapitre {title} - histoire des tunneliers néo-zélandais durant la Première Guerre mondiale",
     "bookChapterDescription": "Lire {title} - un chapitre de Les Kiwis aussi creusent des tunnels, sur les tunneliers néo-zélandais"
   },
+  "howToCite": {
+    "availableAt": "Disponible à\u00A0: "
+  },
   "nav": {
     "history": "Histoire",
     "tunnellers": "Tunneliers",


### PR DESCRIPTION
## What prompted this change?

New Relic reported React #418 hydration errors on book pages. The citation component was rendering an accessed date from `new Date()` during render, which can make SSG/server HTML differ from the browser render.

## Summary of changes

- Render stable citation text for SSG pages and add the accessed date after hydration at the end of the citation.
- Move the copied citation to the final format: `Available at: <url> (Accessed: <date>).`
- Add translated `Available at` labels for English and French, including the French non-breaking space before `:`.
- Refine citation formatting so non-book titles are italicized without quotes, while book citations keep the quoted chapter title and italic book title.
- Update unit snapshots and E2E assertions for the new citation wording.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [x] If appropriate, documentation created or updated. N/A - no documentation change is needed for this citation rendering fix.
