### PR TITLE
[NZT-156] Redirect for old endpoints

### DIFF
--- a/__tests__/e2e/legacy-redirects.spec.ts
+++ b/__tests__/e2e/legacy-redirects.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+test("redirects legacy roll details with an id to the numeric tunneller route", async ({
+  request,
+}) => {
+  const response = await request.get("/roll/details.php?id=123", {
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toContain("/tunnellers/123/");
+});
+
+test("redirects legacy roll details without an id to the tunnellers roll", async ({
+  request,
+}) => {
+  const response = await request.get("/roll/details.php", {
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toContain("/tunnellers/");
+});
+
+test("redirects the legacy roll index to the tunnellers roll", async ({
+  request,
+}) => {
+  const response = await request.get("/roll/index.php", {
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toContain("/tunnellers/");
+});
+
+test("redirects French legacy roll details with an id to the numeric tunneller route", async ({
+  request,
+}) => {
+  const response = await request.get("/fr/liste/details.php?id=123", {
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toContain("/fr/tunnellers/123/");
+});
+
+test("redirects French legacy roll details without an id to the tunnellers roll", async ({
+  request,
+}) => {
+  const response = await request.get("/fr/liste/details.php", {
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toContain("/fr/tunnellers/");
+});
+
+test("redirects the French legacy roll index to the tunnellers roll", async ({
+  request,
+}) => {
+  const response = await request.get("/fr/liste/index.php", {
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toContain("/fr/tunnellers/");
+});

--- a/app/fr/liste/details.php/route.ts
+++ b/app/fr/liste/details.php/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function redirectLegacyFrenchRollDetails(request: NextRequest) {
+  const id = request.nextUrl.searchParams.get("id");
+  const path =
+    id && /^\d+$/.test(id) ? `/fr/tunnellers/${id}/` : "/fr/tunnellers/";
+
+  return NextResponse.redirect(new URL(path, request.url), {
+    status: 308,
+  });
+}
+
+export function GET(request: NextRequest) {
+  return redirectLegacyFrenchRollDetails(request);
+}
+
+export function HEAD(request: NextRequest) {
+  return redirectLegacyFrenchRollDetails(request);
+}

--- a/app/fr/liste/index.php/route.ts
+++ b/app/fr/liste/index.php/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function redirectLegacyFrenchRollIndex(request: NextRequest) {
+  return NextResponse.redirect(new URL("/fr/tunnellers/", request.url), {
+    status: 308,
+  });
+}
+
+export function GET(request: NextRequest) {
+  return redirectLegacyFrenchRollIndex(request);
+}
+
+export function HEAD(request: NextRequest) {
+  return redirectLegacyFrenchRollIndex(request);
+}

--- a/app/roll/details.php/route.ts
+++ b/app/roll/details.php/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function redirectLegacyRollDetails(request: NextRequest) {
+  const id = request.nextUrl.searchParams.get("id");
+  const path = id && /^\d+$/.test(id) ? `/tunnellers/${id}/` : "/tunnellers/";
+
+  return NextResponse.redirect(new URL(path, request.url), {
+    status: 308,
+  });
+}
+
+export function GET(request: NextRequest) {
+  return redirectLegacyRollDetails(request);
+}
+
+export function HEAD(request: NextRequest) {
+  return redirectLegacyRollDetails(request);
+}

--- a/app/roll/index.php/route.ts
+++ b/app/roll/index.php/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function redirectLegacyRollIndex(request: NextRequest) {
+  return NextResponse.redirect(new URL("/tunnellers/", request.url), {
+    status: 308,
+  });
+}
+
+export function GET(request: NextRequest) {
+  return redirectLegacyRollIndex(request);
+}
+
+export function HEAD(request: NextRequest) {
+  return redirectLegacyRollIndex(request);
+}


### PR DESCRIPTION
## What prompted this change?

New Relic showed repeated 404s for legacy roll URLs from the previous site, including English and French PHP endpoints. Some requests include old profile ids, so these routes should redirect users and crawlers to the current roll/profile URLs instead of the custom 404 page.

## Summary of changes

- Added permanent redirects for `/roll/details.php` and `/fr/liste/details.php`, preserving numeric `id` values by sending them to the matching current tunneller route.
- Added permanent redirects for `/roll/index.php` and `/fr/liste/index.php` to the current English and French tunnellers roll pages.
- Added Playwright coverage for the legacy redirect responses and their target locations.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
