### PR TITLE
[NZT-158] HowToCite with trailingSlash

### DIFF
--- a/__tests__/e2e/books.spec.ts
+++ b/__tests__/e2e/books.spec.ts
@@ -263,9 +263,6 @@ test("EN HowToCite: shows correct citation for a book chapter", async ({
   await expect(citation).toContainText("Available at:");
   await expect(citation).toContainText("(Accessed:");
   await expect(citation).toContainText(
-    "www.nztunnellers.com/books/kiwis-dig-tunnels-too/chapter-1-the-tunnellers-from-the-antipodes",
-  );
-  await expect(citation).not.toContainText(
     "www.nztunnellers.com/books/kiwis-dig-tunnels-too/chapter-1-the-tunnellers-from-the-antipodes/",
   );
 });
@@ -287,9 +284,6 @@ test("FR HowToCite: shows correct citation for a book chapter", async ({
   await expect(citation).toContainText("Disponible à");
   await expect(citation).toContainText("(Consulté le");
   await expect(citation).toContainText(
-    "www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapter-1-the-tunnellers-from-the-antipodes",
-  );
-  await expect(citation).not.toContainText(
     "www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapter-1-the-tunnellers-from-the-antipodes/",
   );
 });

--- a/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
+++ b/__tests__/unit/components/Article/__snapshots__/Article.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`Article matches the snapshot 1`] = `
         <span>
           Available at: 
           <wbr />
-          www.nztunnellers.com/history/my-awesome-article
+          www.nztunnellers.com/history/my-awesome-article/
         </span>
          (Accessed: 4 May 2023)
       </p>

--- a/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
+++ b/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`Chapter matches the snapshot 1`] = `
         <span>
           Disponible à : 
           <wbr />
-          www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapitre-1-les-tunneliers-des-antipodes
+          www.nztunnellers.com/fr/books/kiwis-dig-tunnels-too/chapitre-1-les-tunneliers-des-antipodes/
         </span>
          (Consulté le : 1 janvier 2025)
       </p>

--- a/__tests__/unit/components/HowToCite/HowToCite.test.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.test.tsx
@@ -106,9 +106,8 @@ describe("HowToCite", () => {
       writeTextSpy.mock.calls[writeTextSpy.mock.calls.length - 1][0];
 
     expect(copiedText).toContain(
-      "www.nztunnellers.com/books/kiwis-dig-tunnels-too/prologue",
+      "www.nztunnellers.com/books/kiwis-dig-tunnels-too/prologue/",
     );
-    expect(copiedText).not.toContain("prologue/");
 
     jest.restoreAllMocks();
   });

--- a/__tests__/unit/components/HowToCite/utils/citationFormatters.test.ts
+++ b/__tests__/unit/components/HowToCite/utils/citationFormatters.test.ts
@@ -51,7 +51,7 @@ describe("citationFormatters", () => {
         title: "Beneath Artois Fields",
         locale: "en",
       }),
-    ).toBe("www.nztunnellers.com/history/beneath-artois-fields");
+    ).toBe("www.nztunnellers.com/history/beneath-artois-fields/");
   });
 
   test("builds a timeline URL for a French tunneller page", () => {
@@ -61,15 +61,23 @@ describe("citationFormatters", () => {
         timeline: true,
         locale: "fr",
       }),
-    ).toBe("www.nztunnellers.com/fr/tunnellers/john-doe/wwi-timeline");
+    ).toBe("www.nztunnellers.com/fr/tunnellers/john-doe/wwi-timeline/");
   });
 
-  test("removes trailing slashes from pathname URLs", () => {
+  test("keeps trailing slashes in pathname URLs", () => {
     expect(
       buildCitationUrl({
         pathname: "/books/kiwis-dig-tunnels-too/prologue/",
       }),
-    ).toBe("www.nztunnellers.com/books/kiwis-dig-tunnels-too/prologue");
+    ).toBe("www.nztunnellers.com/books/kiwis-dig-tunnels-too/prologue/");
+  });
+
+  test("adds trailing slashes to pathname URLs", () => {
+    expect(
+      buildCitationUrl({
+        pathname: "/books/kiwis-dig-tunnels-too/prologue",
+      }),
+    ).toBe("www.nztunnellers.com/books/kiwis-dig-tunnels-too/prologue/");
   });
 
   test("formats a chapter path fragment", () => {

--- a/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
+++ b/__tests__/unit/components/Profile/__snapshots__/Profile.test.tsx.snap
@@ -357,7 +357,7 @@ exports[`Profile matches the snapshot 1`] = `
           <span>
             Available at: 
             <wbr />
-            www.nztunnellers.com/tunnellers/harry-corrin--4_1415
+            www.nztunnellers.com/tunnellers/harry-corrin--4_1415/
           </span>
            (Accessed: 4 May 2023)
         </p>

--- a/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
+++ b/__tests__/unit/components/Timeline/__snapshots__/Timeline.test.tsx.snap
@@ -462,7 +462,7 @@ exports[`Timeline matches the snapshot 1`] = `
         <span>
           Available at: 
           <wbr />
-          www.nztunnellers.com/tunnellers/harry-corrin--4_1415/wwi-timeline
+          www.nztunnellers.com/tunnellers/harry-corrin--4_1415/wwi-timeline/
         </span>
          (Accessed: 4 May 2023)
       </p>

--- a/components/HowToCite/utils/citationFormatters.ts
+++ b/components/HowToCite/utils/citationFormatters.ts
@@ -27,6 +27,10 @@ const citationMessages = {
   fr: frMessages.howToCite,
 } as const;
 
+function withTrailingSlash(path: string): string {
+  return path.replace(/\/+$/, "") + "/";
+}
+
 export function sentenceCase(str: string): string {
   const lower = str.toLowerCase();
   return lower.charAt(0).toUpperCase() + lower.slice(1);
@@ -104,7 +108,7 @@ export function buildCitationUrl({
   locale = "en",
 }: CitationUrlParams): string {
   if (pathname) {
-    return `www.nztunnellers.com${pathname.replace(/\/+$/, "")}`;
+    return `www.nztunnellers.com${withTrailingSlash(pathname)}`;
   }
 
   const localePrefix = locale === "en" ? "" : `/${locale}`;
@@ -116,15 +120,15 @@ export function buildCitationUrl({
       .toLowerCase();
 
   if (tunnellerSlug && timeline) {
-    return `www.nztunnellers.com${localePrefix}/tunnellers/${tunnellerSlug}/wwi-timeline`;
+    return `www.nztunnellers.com${localePrefix}/tunnellers/${tunnellerSlug}/wwi-timeline/`;
   }
 
   if (tunnellerSlug) {
-    return `www.nztunnellers.com${localePrefix}/tunnellers/${tunnellerSlug}`;
+    return `www.nztunnellers.com${localePrefix}/tunnellers/${tunnellerSlug}/`;
   }
 
   if (historySlug) {
-    return `www.nztunnellers.com${localePrefix}/history/${historySlug}`;
+    return `www.nztunnellers.com${localePrefix}/history/${historySlug}/`;
   }
 
   return `www.nztunnellers.com${localePrefix}/`;


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
HowToCite does not show the trailingSlash when currently the website uses the trailingSlash.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Update citation url

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [x] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
