### PR TITLE
[NZT-165] Fix date for book

### DIFF
--- a/__tests__/e2e/books.spec.ts
+++ b/__tests__/e2e/books.spec.ts
@@ -259,7 +259,7 @@ test("EN HowToCite: shows correct citation for a book chapter", async ({
     "Chapter 1: The Tunnellers from the Antipodes",
   );
   await expect(citation).toContainText("Kiwis Dig Tunnels Too");
-  await expect(citation).toContainText("New Zealand Tunnellers, 2009.");
+  await expect(citation).toContainText("New Zealand Tunnellers, 2017.");
   await expect(citation).toContainText("Available at:");
   await expect(citation).toContainText("(Accessed:");
   await expect(citation).toContainText(
@@ -280,7 +280,7 @@ test("FR HowToCite: shows correct citation for a book chapter", async ({
   await expect(citation).toContainText("Anthony Byledbal");
   await expect(citation).toContainText("Les Tunneliers des antipodes");
   await expect(citation).toContainText("Les Kiwis aussi creusent des tunnels");
-  await expect(citation).toContainText("New Zealand Tunnellers, 2009.");
+  await expect(citation).toContainText("New Zealand Tunnellers, 2017.");
   await expect(citation).toContainText("Disponible à");
   await expect(citation).toContainText("(Consulté le");
   await expect(citation).toContainText(

--- a/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
+++ b/__tests__/unit/components/Books/Chapter/__snapshots__/Chapter.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`Chapter matches the snapshot 1`] = `
         <em>
           Les Kiwis aussi creusent des tunnels
         </em>
-        , New Zealand Tunnellers, 2009. 
+        , New Zealand Tunnellers, 2017. 
         <span>
           Disponible à : 
           <wbr />

--- a/__tests__/unit/components/HowToCite/HowToCite.test.tsx
+++ b/__tests__/unit/components/HowToCite/HowToCite.test.tsx
@@ -23,6 +23,9 @@ describe("HowToCite", () => {
     );
 
     expect(emphasized).toContain("New Zealand Tunnellers");
+    expect(container.querySelector("p")).toHaveTextContent(
+      "New Zealand Tunnellers, 2009.",
+    );
   });
 
   test("italicizes the book title instead of the site title for book citations", () => {
@@ -40,6 +43,9 @@ describe("HowToCite", () => {
 
     expect(emphasized).toContain("Kiwis Dig Tunnels Too");
     expect(emphasized).not.toContain("New Zealand Tunnellers");
+    expect(container.querySelector("p")).toHaveTextContent(
+      "New Zealand Tunnellers, 2017.",
+    );
   });
 
   test("shows English success alert on clipboard copy", async () => {

--- a/components/HowToCite/HowToCite.tsx
+++ b/components/HowToCite/HowToCite.tsx
@@ -36,6 +36,9 @@ type HowToCiteUrlProps = {
   locale?: string;
 };
 
+const SITE_CITATION_YEAR = "2009";
+const BOOK_CITATION_YEAR = "2017";
+
 export function HowToCiteUrl({
   tunnellerSlug,
   title,
@@ -115,6 +118,9 @@ export function HowToCite({
       pathname ? (chapterTitle ?? formatBookSubpath(pathname, locale)) : null,
     [chapterTitle, pathname, locale],
   );
+  const citationYear = citationChapterTitle
+    ? BOOK_CITATION_YEAR
+    : SITE_CITATION_YEAR;
 
   const handleCopy = () => {
     if (citationRef.current) {
@@ -178,7 +184,7 @@ export function HowToCite({
         ) : (
           <em>New Zealand Tunnellers</em>
         )}
-        {", 2009. "}
+        {`, ${citationYear}. `}
         <HowToCiteUrl
           tunnellerSlug={tunnellerSlug}
           title={title}


### PR DESCRIPTION
## What prompted this change?

<!--- Add a description detailing what prompted this change. For external contributors, add link to proposal document --->
The HowToCite component only handle one date, which is the creation date of the website (aka 2009). However, the book added to the Resources is from 2017.

## Summary of changes

<!--- Add bullet point(s) summarising your changes --->
- Fix date for book.

## Checklist

- [ ] PR comments added to highlight areas that may need particular scrutiny or discussion;
- [ ] Unit and integration tests added or updated, and coverage is maintained or improved;
- [ ] If appropriate, documentation created or updated.
